### PR TITLE
feat: add issue triage ci

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,23 @@
+# Add github issues to projects board on creation
+
+# Required Secrets
+# - PROJECTS_ACCESS_TOKEN
+
+name: Add issues project
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@RELEASE_VERSION
+        with:
+          # You can target a repository in a different organization
+          # to the issue
+          project-url: https://github.com/orgs/e-picsa/projects/1
+          github-token: ${{ secrets.PROJECTS_ACCESS_TOKEN }}
+          # labeled: bug, needs-triage
+          # label-operator: OR


### PR DESCRIPTION
## Description

- Add automation to automatically add new issues to main project board
https://github.com/orgs/e-picsa/projects/1/views/1