### PR TITLE
Fix/android permissions

### DIFF
--- a/apps/picsa-apps/extension-app-native/android/app/build.gradle
+++ b/apps/picsa-apps/extension-app-native/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "io.picsa.extension"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 3013000
-        versionName "3.13.0"
+        versionCode 3013001
+        versionName "3.13.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/apps/picsa-apps/extension-app-native/android/app/src/main/AndroidManifest.xml
+++ b/apps/picsa-apps/extension-app-native/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
     package="io.picsa.extension">
 
+    <!-- HACK - 
+    remove permission from fileopener2 https://github.com/pwlin/cordova-plugin-file-opener2/issues/329 
+    (also requires xmlns:tools="http://schemas.android.com/tools" in manifest tag above)
+    -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="remove"/>
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/apps/picsa-apps/extension-app/project.json
+++ b/apps/picsa-apps/extension-app/project.json
@@ -77,8 +77,7 @@
               "with": "libs/environments/src/environment.prod.ts"
             }
           ],
-          "outputHashing": "all",
-          "sourceMap": true
+          "outputHashing": "all"
         },
         "development": {
           "buildOptimizer": false,

--- a/documentation/developers/troubleshooting.md
+++ b/documentation/developers/troubleshooting.md
@@ -25,3 +25,15 @@ Known issue, related to how jest will attempt to recompile prior to running. Hav
 - https://github.com/thymikee/jest-preset-angular/issues/1648
 
 Will likely need to fork and rebuild repo to add better support (assuming esm module syntax)
+
+### Play store rejected - sensitive permissions (REQUEST_INSTALL_PACKAGES )
+
+Update `apps\picsa-apps\extension-app-native\android\app\src\main\AndroidManifest.xml` to remove permission
+
+```
+<uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="remove"/>
+```
+
+This will also require adding `xmlns:tools="http://schemas.android.com/tools"` in manifest tag
+
+See notes in https://github.com/pwlin/cordova-plugin-file-opener2/issues/329

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picsa-apps",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "license": "See LICENSE",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Description

Recently play store policy updates reject apps that request permission `REQUEST_INSTALL_PACKAGES`, which is included in the file opening plugin we use. As the permission isn't strictly required for main file opening functionality have provided a small workaround to remove the permission from the build. 

## Discussion

_Feedback discussion points if relevant (should also tag as `Feedback Discussion`)_

## Preview

_Link to app preview if relevant_
https://picsa.app

## Screenshots / Videos

_Include at least 1-2 screenshots of videos if visual changes_
