### PR TITLE
fix: deprecate legacy network service to resolve vpn permissions

### DIFF
--- a/apps/picsa-apps/extension-app-native/android/app/build.gradle
+++ b/apps/picsa-apps/extension-app-native/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "io.picsa.extension"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 3013001
-        versionName "3.13.1"
+        versionCode 3013002
+        versionName "3.13.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/apps/picsa-apps/extension-app-native/android/app/src/main/assets/capacitor.config.json
+++ b/apps/picsa-apps/extension-app-native/android/app/src/main/assets/capacitor.config.json
@@ -8,8 +8,6 @@
 		"cordova-plugin-file-opener2",
 		"@awesome-cordova-plugins/file",
 		"cordova-plugin-file",
-		"@awesome-cordova-plugins/network",
-		"cordova-plugin-network",
 		"@awesome-cordova-plugins/social-sharing",
 		"cordova-plugin-x-socialsharing",
 		"cordova-plugin-codeplay-share-own-apk",

--- a/apps/picsa-apps/extension-app-native/android/app/src/main/res/xml/config.xml
+++ b/apps/picsa-apps/extension-app-native/android/app/src/main/res/xml/config.xml
@@ -11,11 +11,6 @@
     <param name="onload" value="true"/>
   </feature>
 
-  <feature name="NetworkPlugin">
-    <param name="android-package" value="com.fytoro.network.NetworkPlugin"/>
-    <param name="onload" value="true"/>
-  </feature>
-
   <feature name="SocialSharing">
     <param name="android-package" value="nl.xservices.plugins.SocialSharing"/>
   </feature>

--- a/apps/picsa-apps/extension-app-native/capacitor.config.ts
+++ b/apps/picsa-apps/extension-app-native/capacitor.config.ts
@@ -13,8 +13,6 @@ const config: CapacitorConfig = {
     'cordova-plugin-file-opener2',
     '@awesome-cordova-plugins/file',
     'cordova-plugin-file',
-    '@awesome-cordova-plugins/network',
-    'cordova-plugin-network',
     '@awesome-cordova-plugins/social-sharing',
     'cordova-plugin-x-socialsharing',
     // cordova standalone

--- a/libs/shared/src/services/native/network.ts
+++ b/libs/shared/src/services/native/network.ts
@@ -1,21 +1,32 @@
 import { Injectable } from '@angular/core';
-import { Network } from '@awesome-cordova-plugins/network/ngx';
+
+/**
+ * TODO - cordova network plugin uses vpn which requires extra permissions
+ * Should refactor if required to use capacitor netowrk
+ */
+// import { Network } from '@awesome-cordova-plugins/network/ngx';
+
 import { Platform } from '@ionic/angular';
 
 @Injectable({ providedIn: 'root' })
 export class NetworkProvider {
-  online = false;
+  private online = false;
 
-  constructor(private network: Network, private platform: Platform) {
+  private network: any;
+  // private network: Network
+
+  constructor(private platform: Platform) {
     console.log('Hello NetworkProvider Provider');
   }
-  init() {
-    this.online = this.getNetworkStatus();
-    console.log('online?', this.online);
-    this.subscribeToNetworkChanges();
+  private init() {
+    console.error('Network not currently supported');
+    return;
+    // this.online = this.getNetworkStatus();
+    // console.log('online?', this.online);
+    // this.subscribeToNetworkChanges();
   }
 
-  getNetworkStatus() {
+  private getNetworkStatus() {
     if (this.platform.is('cordova')) {
       return this.network.type != 'none';
     } else {
@@ -23,7 +34,7 @@ export class NetworkProvider {
     }
   }
 
-  subscribeToNetworkChanges() {
+  private subscribeToNetworkChanges() {
     console.log('subscribing to network changes');
     if (this.platform.is('cordova')) {
       this.network.onDisconnect().subscribe(() => {
@@ -43,6 +54,4 @@ export class NetworkProvider {
   updateOfflineStatus(e) {
     this.online = false;
   }
-
-  updateReduxOnlineStatus() {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picsa-apps",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "license": "See LICENSE",
   "scripts": {
     "ng": "nx",
@@ -52,7 +52,6 @@
     "cordova-plugin-codeplay-share-own-apk": "0.0.7",
     "cordova-plugin-file": "^7.0.0",
     "cordova-plugin-file-opener2": "^3.0.5",
-    "cordova-plugin-network": "^1.0.1",
     "cordova-plugin-x-socialsharing": "^6.0.4",
     "deepmerge": "^4.2.2",
     "dexie": "^3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7471,13 +7471,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cordova-plugin-network@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "cordova-plugin-network@npm:1.0.1"
-  checksum: 05dac758cbcf311b607d5300a5657c075542c18886523be1f6b30da643d2b5c809730937f6dc8ccd663e7a558b899c5f3aa2cdbf411c820c9b2f728591a58770
-  languageName: node
-  linkType: hard
-
 "cordova-plugin-x-socialsharing@npm:^6.0.4":
   version: 6.0.4
   resolution: "cordova-plugin-x-socialsharing@npm:6.0.4"
@@ -14338,7 +14331,6 @@ __metadata:
     cordova-plugin-codeplay-share-own-apk: 0.0.7
     cordova-plugin-file: ^7.0.0
     cordova-plugin-file-opener2: ^3.0.5
-    cordova-plugin-network: ^1.0.1
     cordova-plugin-x-socialsharing: ^6.0.4
     cypress: ^9.1.0
     deepmerge: ^4.2.2


### PR DESCRIPTION
## Description

_Summary of main changes_

## Discussion

Further play store compliance resolutions, this time `android.permission.BIND_VPN_SERVICE` which is included in the plugin used to detect online/offline network status. As this feature is not currently in use simply deprecate for now and remove the plugin

## Preview

_Link to app preview if relevant_
https://picsa.app

## Screenshots / Videos

_Include at least 1-2 screenshots of videos if visual changes_
