### PR TITLE
refactor: replace angular-fire with firebase v9

### DIFF
--- a/apps/picsa-tools/budget-tool/src/app/components/share-dialog/share-dialog.component.html
+++ b/apps/picsa-tools/budget-tool/src/app/components/share-dialog/share-dialog.component.html
@@ -5,7 +5,7 @@
       mat-button
       (click)="sharePicture()"
       [disabled]="disabled"
-      style="margin-right: 4px"
+      style="margin-right: 4px; height: 100%"
     >
       <div style="margin-top: 8px">
         <img
@@ -20,7 +20,7 @@
       mat-button
       (click)="shareLink()"
       [disabled]="disabled"
-      style="margin-left: 4px"
+      style="margin-left: 4px; height: 100%"
     >
       <div style="margin-top: 8px">
         <img

--- a/libs/shared/src/mocks/db.mock.ts
+++ b/libs/shared/src/mocks/db.mock.ts
@@ -1,8 +1,6 @@
 import { IDBEndpoint, IDBDoc } from '@picsa/models';
 import { _wait } from '@picsa/utils';
 import { AbstractDBService } from '../services/core/db/abstract.db';
-import firebase from 'firebase/compat/app';
-import 'firebase/compat/firestore';
 
 export class MockDB implements AbstractDBService {
   async getCollection(endpoint: IDBEndpoint) {
@@ -34,15 +32,13 @@ export class MockDB implements AbstractDBService {
   meta(doc: any = {}): IDBDoc {
     const { _key, _created, _modified } = doc;
     return {
-      _key: _key ? _key : this._generateKey(),
+      _key: _key ? _key : this.randomKey(),
       _created: _created ?? new Date().toISOString(),
       _modified: _modified ?? new Date().toISOString(),
     };
   }
 
-  private _generateKey = () => {
-    const key = firebase.firestore().collection('_').doc().id;
-    console.log('key', key);
-    return key;
+  private randomKey = () => {
+    return Math.random().toString(36).substring(2, 15);
   };
 }

--- a/libs/shared/src/modules/db.module.ts
+++ b/libs/shared/src/modules/db.module.ts
@@ -1,9 +1,4 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { AngularFireModule, FIREBASE_OPTIONS } from '@angular/fire/compat';
-import { AngularFirestoreModule } from '@angular/fire/compat/firestore';
-import { AngularFireAuthModule } from '@angular/fire/compat/auth';
-import { ENVIRONMENT } from '@picsa/environments';
 import { PicsaDbService } from '../services/core/db';
 import { DBCacheService } from '../services/core/db/_cache.db';
 import { DBServerService } from '../services/core/db/_server.db';
@@ -11,15 +6,7 @@ import { DBSyncService } from '../services/core/db/sync.service';
 
 // initiate db and auth in shared lib to be available throughout app
 @NgModule({
-  imports: [
-    CommonModule,
-    // note, due to AOT build issues not calling initialise but pass provider below
-    // see https://github.com/angular/angularfire2/issues/1635
-    AngularFireModule,
-    AngularFirestoreModule,
-    AngularFireAuthModule,
-  ],
-  providers: [{ provide: FIREBASE_OPTIONS, useValue: ENVIRONMENT.firebase }],
+  imports: [],
 })
 export class PicsaDbModule {
   static forRoot(): ModuleWithProviders<PicsaDbModule> {

--- a/libs/shared/src/services/core/auth.service.ts
+++ b/libs/shared/src/services/core/auth.service.ts
@@ -1,7 +1,0 @@
-import { Injectable } from '@angular/core';
-import { AngularFireAuth } from '@angular/fire/auth';
-
-@Injectable({ providedIn: 'root' })
-export class AuthService {
-  constructor(private auth: AngularFireAuth) {}
-}

--- a/libs/shared/src/services/core/db/_server.db.ts
+++ b/libs/shared/src/services/core/db/_server.db.ts
@@ -1,45 +1,59 @@
 import { Injectable } from '@angular/core';
-import { AngularFirestore } from '@angular/fire/compat/firestore';
+import {
+  getFirestore,
+  Firestore,
+  collection,
+  query,
+  where,
+  getDocs,
+  setDoc as firebaseSetDoc,
+  doc,
+  getDoc as firebaseGetDoc,
+  writeBatch,
+} from 'firebase/firestore';
+
 import type { IDBEndpoint, IDBDoc } from '@picsa/models';
 import { AbstractDBService } from './abstract.db';
+import { PicsaFirebaseService } from '../firebase.service';
 
 @Injectable({ providedIn: 'root' })
 export class DBServerService implements AbstractDBService {
-  constructor(private afs: AngularFirestore) {}
+  private firestore: Firestore;
+  constructor(firebaseService: PicsaFirebaseService) {
+    this.firestore = getFirestore(firebaseService.app);
+  }
 
   /************************************************************************
    *  Main Methods - taken from abstract class
    ***********************************************************************/
 
   public async getCollection<T>(endpoint: IDBEndpoint, newerThan = '') {
-    const snapshot = await this.afs
-      .collection<T>(endpoint, (ref) => ref.where('_modified', '>', newerThan))
-      .get()
-      .toPromise();
-    return snapshot
-      ? (snapshot.docs.map((d) => d.data()) as (T & IDBDoc)[])
-      : [];
+    const ref = collection(this.firestore, endpoint);
+    const q = query(ref, where('_modified', '>', newerThan));
+    const querySnapshot = await getDocs(q);
+    return querySnapshot.docs.map((d) => d.data()) as (T & IDBDoc)[];
   }
 
   public async getDoc<T>(endpoint: IDBEndpoint, key: string) {
-    const snapshot = await this.afs
-      .doc<T & IDBDoc>(`${endpoint}/${key}`)
-      .get()
-      .toPromise();
-    return snapshot ? (snapshot.data() as T & IDBDoc) : (null as any);
+    const ref = doc(this.firestore, `${endpoint}/${key}`);
+    const snapshot = await firebaseGetDoc(ref);
+    if (snapshot.exists()) {
+      return snapshot.data as T & IDBDoc;
+    }
+    return undefined;
   }
 
-  public async setDoc<T>(endpoint: IDBEndpoint, doc: T & IDBDoc) {
-    this.afs.firestore.doc(`${endpoint}/${doc._key}`).set(doc);
-    await this.afs.firestore.doc(`${endpoint}/${doc._key}`).set(doc);
-    return doc;
+  public async setDoc<T>(endpoint: IDBEndpoint, data: T & IDBDoc) {
+    const ref = doc(this.firestore, `${endpoint}/${data._key}`);
+    await firebaseSetDoc(ref, data);
+    return data;
   }
 
   public async setDocs<T>(endpoint: IDBEndpoint, docs: (T & IDBDoc)[]) {
-    const batch = this.afs.firestore.batch();
-    for (let doc of docs) {
-      const ref = this.afs.firestore.collection(endpoint).doc(doc._key);
-      batch.set(ref, doc);
+    const batch = writeBatch(this.firestore);
+    for (const data of docs) {
+      const ref = doc(this.firestore, endpoint, data._key);
+      batch.set(ref, data);
     }
     await batch.commit();
     return docs;
@@ -52,9 +66,9 @@ export class DBServerService implements AbstractDBService {
     keys: string[],
     subcollection?: string
   ) {
-    const batch = this.afs.firestore.batch();
-    for (let key of keys) {
-      const ref = this.afs.firestore.collection(endpoint).doc(key);
+    const batch = writeBatch(this.firestore);
+    for (const key of keys) {
+      const ref = doc(this.firestore, endpoint, key);
       batch.delete(ref);
     }
     return batch.commit();
@@ -65,12 +79,13 @@ export class DBServerService implements AbstractDBService {
    ***********************************************************************/
 
   // similar to setDocs above but allow for multiple different endpoints (useful for sync methods)
-  public async setMultiple(refs: { endpoint: IDBEndpoint; doc: IDBDoc }[]) {
-    const batch = this.afs.firestore.batch();
+  public async setMultiple(refs: { endpoint: IDBEndpoint; data: IDBDoc }[]) {
+    const batch = writeBatch(this.firestore);
     // TODO - limit batch methods to process chunks of 500
-    for (let r of refs) {
-      const ref = this.afs.firestore.collection(r.endpoint).doc(r.doc._key);
-      batch.set(ref, r.doc);
+    for (const r of refs) {
+      const { endpoint, data } = r;
+      const ref = doc(this.firestore, endpoint, data._key);
+      batch.set(ref, data);
     }
     await batch.commit();
     return refs;

--- a/libs/shared/src/services/core/db/_server.db.ts
+++ b/libs/shared/src/services/core/db/_server.db.ts
@@ -79,7 +79,8 @@ export class DBServerService implements AbstractDBService {
    ***********************************************************************/
 
   // similar to setDocs above but allow for multiple different endpoints (useful for sync methods)
-  public async setMultiple(refs: { endpoint: IDBEndpoint; data: IDBDoc }[]) {
+
+  public async setMultiple(refs: IServerWriteBatchEntry[]) {
     const batch = writeBatch(this.firestore);
     // TODO - limit batch methods to process chunks of 500
     for (const r of refs) {
@@ -106,3 +107,7 @@ export class DBServerService implements AbstractDBService {
   // }
 }
 // export default DBServerService;
+export interface IServerWriteBatchEntry {
+  endpoint: IDBEndpoint;
+  data: IDBDoc;
+}

--- a/libs/shared/src/services/core/db/db.service.ts
+++ b/libs/shared/src/services/core/db/db.service.ts
@@ -113,7 +113,12 @@ export class PicsaDbService implements AbstractDBService {
   private async syncDoc<T>(endpoint: IDBEndpoint, key: string) {
     // TODO - add retrieval of latest doc and just query after
     const doc = await this.server.getDoc<T>(endpoint, key);
-    return this.cache.setDoc<T>(endpoint, doc);
+    if (doc) {
+      return this.cache.setDoc<T>(endpoint, doc);
+    } else {
+      // TODO - delete local
+      return;
+    }
   }
 
   /************************************************************************

--- a/libs/shared/src/services/core/firebase.service.ts
+++ b/libs/shared/src/services/core/firebase.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Capacitor } from '@capacitor/core';
+import { ENVIRONMENT } from '@picsa/environments/src';
+import { FirebaseApp, initializeApp } from 'firebase/app';
+
+@Injectable({ providedIn: 'root' })
+export class PicsaFirebaseService {
+  public app: FirebaseApp;
+  constructor() {
+    // if (!Capacitor.isNativePlatform()) {
+    this.app = initializeApp(ENVIRONMENT.firebase);
+    // }
+  }
+}

--- a/libs/shared/src/services/core/performance.service.ts
+++ b/libs/shared/src/services/core/performance.service.ts
@@ -1,13 +1,23 @@
 import { Injectable } from '@angular/core';
+import {
+  getPerformance,
+  FirebasePerformance as IFirebasePerformance,
+} from '@firebase/performance';
 import { FirebasePerformance } from '@capacitor-firebase/performance';
+import { PicsaFirebaseService } from './firebase.service';
 
 @Injectable({ providedIn: 'root' })
 /**
  * Monitor app performance via firebase performance monitoring
  * https://firebase.google.com/docs/perf-mon/get-started-android
- * https://www.npmjs.com/package/@capacitor-firebase/performance
+ * https://www.npmjs.com/package/@capacitor-firebase/performanceF
  * */
 export class PerformanceService {
+  private performance: IFirebasePerformance;
+
+  constructor(firebaseService: PicsaFirebaseService) {
+    this.performance = getPerformance(firebaseService.app);
+  }
   public startTrace = FirebasePerformance.startTrace;
 
   public stopTrace = async (traceName: string) => {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@angular/common": "15.1.2",
     "@angular/compiler": "15.1.2",
     "@angular/core": "15.1.2",
-    "@angular/fire": "^7.3.0",
     "@angular/forms": "15.1.2",
     "@angular/material": "15.1.2",
     "@angular/platform-browser": "15.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,24 +134,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-devkit/core@npm:14.0.2":
-  version: 14.0.2
-  resolution: "@angular-devkit/core@npm:14.0.2"
-  dependencies:
-    ajv: 8.11.0
-    ajv-formats: 2.1.1
-    jsonc-parser: 3.0.0
-    rxjs: 6.6.7
-    source-map: 0.7.3
-  peerDependencies:
-    chokidar: ^3.5.2
-  peerDependenciesMeta:
-    chokidar:
-      optional: true
-  checksum: bcc64c1f7307b97acc272b54a3c7c7cd160cad1c8349de802034b6bf6f631c50448aacea6ca8b9569a41981f16546029142a9084904b77ed1be9d940f2822807
-  languageName: node
-  linkType: hard
-
 "@angular-devkit/core@npm:15.0.4":
   version: 15.0.4
   resolution: "@angular-devkit/core@npm:15.0.4"
@@ -185,19 +167,6 @@ __metadata:
     chokidar:
       optional: true
   checksum: 7bc98ab63860fb0d44a3b4910751c70463e41bb1e1c0c34ccd426880b1b56c8d39315d458aa685731277538ce7db1f3fc263442fb6bd9ca4505dc2bdc12452d3
-  languageName: node
-  linkType: hard
-
-"@angular-devkit/schematics@npm:14.0.2, @angular-devkit/schematics@npm:^12.0.0 || ^13.0.0 || ^14.0.0":
-  version: 14.0.2
-  resolution: "@angular-devkit/schematics@npm:14.0.2"
-  dependencies:
-    "@angular-devkit/core": 14.0.2
-    jsonc-parser: 3.0.0
-    magic-string: 0.26.1
-    ora: 5.4.1
-    rxjs: 6.6.7
-  checksum: e056e712741a8c8b900464fbb98709ff42069911b301d27cd498cb5e6035d945bdb7867390305e8500ecee1e3d76100cf1ae5a6fc56bd270b2f41f79a334bcf5
   languageName: node
   linkType: hard
 
@@ -406,41 +375,6 @@ __metadata:
     rxjs: ^6.5.3 || ^7.4.0
     zone.js: ~0.11.4 || ~0.12.0
   checksum: d1b6f55be7ad976ec06fcf45ad14217e2f3c597c30f8735aa3fbd1a31bb5dc1b4ae49784e68215361e33c0e7c05274234df8b9ac83612d42017a032b2ac6a06f
-  languageName: node
-  linkType: hard
-
-"@angular/fire@npm:^7.3.0":
-  version: 7.4.1
-  resolution: "@angular/fire@npm:7.4.1"
-  dependencies:
-    "@angular-devkit/schematics": ^12.0.0 || ^13.0.0 || ^14.0.0
-    "@schematics/angular": ^12.0.0 || ^13.0.0 || ^14.0.0
-    file-loader: ^6.2.0
-    firebase: ^9.8.0
-    fs-extra: ^8.0.1
-    fuzzy: ^0.1.3
-    inquirer: ^8.1.1
-    inquirer-autocomplete-prompt: ^1.0.1
-    jsonc-parser: ^3.0.0
-    node-fetch: ^2.6.1
-    open: ^8.0.0
-    ora: ^5.3.0
-    rxfire: ^6.0.0
-    semver: ^7.1.3
-    triple-beam: ^1.3.0
-    tslib: ^2.0.0
-    winston: ^3.0.0
-  peerDependencies:
-    "@angular/common": ^12.0.0 || ^13.0.0 || ^14.0.0
-    "@angular/core": ^12.0.0 || ^13.0.0 || ^14.0.0
-    "@angular/platform-browser": ^12.0.0 || ^13.0.0 || ^14.0.0
-    "@angular/platform-browser-dynamic": ^12.0.0 || ^13.0.0 || ^14.0.0
-    firebase-tools: ^9.9.0 || ^10.0.0 || ^11.0.0
-    rxjs: ~6.6.0 || ^7.0.0
-  peerDependenciesMeta:
-    firebase-tools:
-      optional: true
-  checksum: 77cc1b2929b6f9f866303aad4773f2527f479bf4486f1423cecefa9b11e4467e7ca5a991e6fc3d8b79bd1ef508038be6b13f4c55d3a21cc9a26e65d82326912b
   languageName: node
   linkType: hard
 
@@ -3475,17 +3409,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dabh/diagnostics@npm:^2.0.2":
-  version: 2.0.3
-  resolution: "@dabh/diagnostics@npm:2.0.3"
-  dependencies:
-    colorspace: 1.1.x
-    enabled: 2.0.x
-    kuler: ^2.0.0
-  checksum: 4879600c55c8315a0fb85fbb19057bad1adc08f0a080a8cb4e2b63f723c379bfc4283b68123a2b078d367b327dd8df12fcb27464efe791addc0a48b9df6d79a1
-  languageName: node
-  linkType: hard
-
 "@discoveryjs/json-ext@npm:0.5.7":
   version: 0.5.7
   resolution: "@discoveryjs/json-ext@npm:0.5.7"
@@ -6310,17 +6233,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@schematics/angular@npm:^12.0.0 || ^13.0.0 || ^14.0.0":
-  version: 14.0.2
-  resolution: "@schematics/angular@npm:14.0.2"
-  dependencies:
-    "@angular-devkit/core": 14.0.2
-    "@angular-devkit/schematics": 14.0.2
-    jsonc-parser: 3.0.0
-  checksum: 5ca2f86141da12ca2a613ee3fa46178ce3df80c2034508d97e453bc6e1d2b6833c6fc39c933f18d06d995e2ebbc14b095c90dd439cd6d22db09d9ce8ebcae3f1
-  languageName: node
-  linkType: hard
-
 "@sinclair/typebox@npm:^0.23.3":
   version: 0.23.5
   resolution: "@sinclair/typebox@npm:0.23.5"
@@ -7857,7 +7769,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-escapes@npm:^4.2.1, ansi-escapes@npm:^4.3.0, ansi-escapes@npm:^4.3.1":
+"ansi-escapes@npm:^4.2.1, ansi-escapes@npm:^4.3.0":
   version: 4.3.2
   resolution: "ansi-escapes@npm:4.3.2"
   dependencies:
@@ -9037,7 +8949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-convert@npm:^1.9.0, color-convert@npm:^1.9.3":
+"color-convert@npm:^1.9.0":
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
   dependencies:
@@ -9069,7 +8981,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-string@npm:^1.6.0, color-string@npm:^1.9.0":
+"color-string@npm:^1.9.0":
   version: 1.9.1
   resolution: "color-string@npm:1.9.1"
   dependencies:
@@ -9085,16 +8997,6 @@ __metadata:
   bin:
     color-support: bin.js
   checksum: 9b7356817670b9a13a26ca5af1c21615463b500783b739b7634a0c2047c16cef4b2865d7576875c31c3cddf9dd621fa19285e628f20198b233a5cfdda6d0793b
-  languageName: node
-  linkType: hard
-
-"color@npm:^3.1.3":
-  version: 3.2.1
-  resolution: "color@npm:3.2.1"
-  dependencies:
-    color-convert: ^1.9.3
-    color-string: ^1.6.0
-  checksum: f81220e8b774d35865c2561be921f5652117638dcda7ca4029262046e37fc2444ac7bbfdd110cf1fd9c074a4ee5eda8f85944ffbdda26186b602dd9bb05f6400
   languageName: node
   linkType: hard
 
@@ -9119,16 +9021,6 @@ __metadata:
   version: 2.0.16
   resolution: "colorette@npm:2.0.16"
   checksum: cd55596a3a2d1071c1a28eee7fd8a5387593ff1bd10a3e8d0a6221499311fe34a9f2b9272d77c391e0e003dcdc8934fb2f8d106e7ef1f7516f8060c901d41a27
-  languageName: node
-  linkType: hard
-
-"colorspace@npm:1.1.x":
-  version: 1.1.4
-  resolution: "colorspace@npm:1.1.4"
-  dependencies:
-    color: ^3.1.3
-    text-hex: 1.0.x
-  checksum: bb3934ef3c417e961e6d03d7ca60ea6e175947029bfadfcdb65109b01881a1c0ecf9c2b0b59abcd0ee4a0d7c1eae93beed01b0e65848936472270a0b341ebce8
   languageName: node
   linkType: hard
 
@@ -10656,13 +10548,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enabled@npm:2.0.x":
-  version: 2.0.0
-  resolution: "enabled@npm:2.0.0"
-  checksum: 9d256d89f4e8a46ff988c6a79b22fa814b4ffd82826c4fdacd9b42e9b9465709d3b748866d0ab4d442dfc6002d81de7f7b384146ccd1681f6a7f868d2acca063
-  languageName: node
-  linkType: hard
-
 "encodeurl@npm:~1.0.2":
   version: 1.0.2
   resolution: "encodeurl@npm:1.0.2"
@@ -11653,13 +11538,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fecha@npm:^4.2.0":
-  version: 4.2.3
-  resolution: "fecha@npm:4.2.3"
-  checksum: f94e2fb3acf5a7754165d04549460d3ae6c34830394d20c552197e3e000035d69732d74af04b9bed3283bf29fe2a9ebdcc0085e640b0be3cc3658b9726265e31
-  languageName: node
-  linkType: hard
-
 "figures@npm:3.2.0, figures@npm:^3.0.0, figures@npm:^3.2.0":
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
@@ -11744,7 +11622,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"firebase@npm:^9.8.0, firebase@npm:^9.8.2":
+"firebase@npm:^9.8.2":
   version: 9.8.3
   resolution: "firebase@npm:9.8.3"
   dependencies:
@@ -11801,13 +11679,6 @@ __metadata:
   version: 3.2.5
   resolution: "flatted@npm:3.2.5"
   checksum: 3c436e9695ccca29620b4be5671dd72e5dd0a7500e0856611b7ca9bd8169f177f408c3b9abfa78dfe1493ee2d873e2c119080a8a9bee4e1a186a9e60ca6c89f1
-  languageName: node
-  linkType: hard
-
-"fn.name@npm:1.x.x":
-  version: 1.1.0
-  resolution: "fn.name@npm:1.1.0"
-  checksum: e357144f48cfc9a7f52a82bbc6c23df7c8de639fce049cac41d41d62cabb740cdb9f14eddc6485e29c933104455bdd7a69bb14a9012cef9cd4fa252a4d0cf293
   languageName: node
   linkType: hard
 
@@ -11953,17 +11824,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^8.0.1":
-  version: 8.1.0
-  resolution: "fs-extra@npm:8.1.0"
-  dependencies:
-    graceful-fs: ^4.2.0
-    jsonfile: ^4.0.0
-    universalify: ^0.1.0
-  checksum: bf44f0e6cea59d5ce071bba4c43ca76d216f89e402dc6285c128abc0902e9b8525135aa808adad72c9d5d218e9f4bcc63962815529ff2f684ad532172a284880
-  languageName: node
-  linkType: hard
-
 "fs-extra@npm:^9.0.0, fs-extra@npm:^9.1.0":
   version: 9.1.0
   resolution: "fs-extra@npm:9.1.0"
@@ -12045,13 +11905,6 @@ __metadata:
   version: 1.2.3
   resolution: "functions-have-names@npm:1.2.3"
   checksum: c3f1f5ba20f4e962efb71344ce0a40722163e85bee2101ce25f88214e78182d2d2476aa85ef37950c579eb6cf6ee811c17b3101bb84004bb75655f3e33f3fdb5
-  languageName: node
-  linkType: hard
-
-"fuzzy@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "fuzzy@npm:0.1.3"
-  checksum: acc09c6173e12d5dc8ae51857551ddbe834befa9ebc6be6d5581d09117265d704809d80407d220fd0652f347a9975a4d106854cacc8bd031487a0ede86982f84
   languageName: node
   linkType: hard
 
@@ -12815,22 +12668,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inquirer-autocomplete-prompt@npm:^1.0.1":
-  version: 1.4.0
-  resolution: "inquirer-autocomplete-prompt@npm:1.4.0"
-  dependencies:
-    ansi-escapes: ^4.3.1
-    chalk: ^4.0.0
-    figures: ^3.2.0
-    run-async: ^2.4.0
-    rxjs: ^6.6.2
-  peerDependencies:
-    inquirer: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: 863d60d6beee2424d3fd9fbdbc027dcc36b20106509f56edd0aab49dea8b033451edec5936ca929b24b685a7137097c98c21757889df8a87cd3919a732483586
-  languageName: node
-  linkType: hard
-
-"inquirer@npm:8.2.4, inquirer@npm:^8.1.1":
+"inquirer@npm:8.2.4":
   version: 8.2.4
   resolution: "inquirer@npm:8.2.4"
   dependencies:
@@ -14150,13 +13988,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:3.0.0, jsonc-parser@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "jsonc-parser@npm:3.0.0"
-  checksum: 1df2326f1f9688de30c70ff19c5b2a83ba3b89a1036160da79821d1361090775e9db502dc57a67c11b56e1186fc1ed70b887f25c5febf9a3ec4f91435836c99d
-  languageName: node
-  linkType: hard
-
 "jsonc-parser@npm:3.2.0, jsonc-parser@npm:^3.2.0":
   version: 3.2.0
   resolution: "jsonc-parser@npm:3.2.0"
@@ -14164,15 +13995,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonfile@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "jsonfile@npm:4.0.0"
-  dependencies:
-    graceful-fs: ^4.1.6
-  dependenciesMeta:
-    graceful-fs:
-      optional: true
-  checksum: 6447d6224f0d31623eef9b51185af03ac328a7553efcee30fa423d98a9e276ca08db87d71e17f2310b0263fd3ffa6c2a90a6308367f661dc21580f9469897c9e
+"jsonc-parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "jsonc-parser@npm:3.0.0"
+  checksum: 1df2326f1f9688de30c70ff19c5b2a83ba3b89a1036160da79821d1361090775e9db502dc57a67c11b56e1186fc1ed70b887f25c5febf9a3ec4f91435836c99d
   languageName: node
   linkType: hard
 
@@ -14209,14 +14035,14 @@ __metadata:
   linkType: hard
 
 "jszip@npm:^3.6.0":
-  version: 3.10.0
-  resolution: "jszip@npm:3.10.0"
+  version: 3.10.1
+  resolution: "jszip@npm:3.10.1"
   dependencies:
     lie: ~3.3.0
     pako: ~1.0.2
     readable-stream: ~2.3.6
     setimmediate: ^1.0.5
-  checksum: 80cc8e0e466467e9e21447f604f9262509b29a9c65170a3fee415ac0a403beb370840973cdc17f75d2b92ab3e60685f94d267706510d46bed2dd14858a38e459
+  checksum: abc77bfbe33e691d4d1ac9c74c8851b5761fba6a6986630864f98d876f3fcc2d36817dfc183779f32c00157b5d53a016796677298272a714ae096dfe6b1c8b60
   languageName: node
   linkType: hard
 
@@ -14254,13 +14080,6 @@ __metadata:
   version: 2.0.5
   resolution: "klona@npm:2.0.5"
   checksum: 8c976126ea252b766e648a4866e1bccff9d3b08432474ad80c559f6c7265cf7caede2498d463754d8c88c4759895edd8210c85c0d3155e6aae4968362889466f
-  languageName: node
-  linkType: hard
-
-"kuler@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "kuler@npm:2.0.0"
-  checksum: 9e10b5a1659f9ed8761d38df3c35effabffbd19fc6107324095238e4ef0ff044392cae9ac64a1c2dda26e532426485342226b93806bd97504b174b0dcf04ed81
   languageName: node
   linkType: hard
 
@@ -14587,19 +14406,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"logform@npm:^2.3.2, logform@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "logform@npm:2.4.0"
-  dependencies:
-    "@colors/colors": 1.5.0
-    fecha: ^4.2.0
-    ms: ^2.1.1
-    safe-stable-stringify: ^2.3.1
-    triple-beam: ^1.3.0
-  checksum: e75ccccc1a2664612ade3c7f3d3185787198b4028e54ea2795df87901f28b3881eddd8d7e73ce03f4420dca638a1cbe6d42254179685ab2075e4ac38a71ffb6c
-  languageName: node
-  linkType: hard
-
 "long@npm:^4.0.0":
   version: 4.0.0
   resolution: "long@npm:4.0.0"
@@ -14636,15 +14442,6 @@ __metadata:
   version: 7.10.1
   resolution: "lru-cache@npm:7.10.1"
   checksum: e8b190d71ed0fcd7b29c71a3e9b01f851c92d1ef8865ff06b5581ca991db1e5e006920ed4da8b56da1910664ed51abfd76c46fb55e82ac252ff6c970ff910d72
-  languageName: node
-  linkType: hard
-
-"magic-string@npm:0.26.1":
-  version: 0.26.1
-  resolution: "magic-string@npm:0.26.1"
-  dependencies:
-    sourcemap-codec: ^1.4.8
-  checksum: 23f21f5734346ddfbabd7b9834e3ecda3521e3e1db81166c1513b45b729489bbed1eafa8cd052c7db7fdc7c68ebc5c03bc00dd5a23697edda15dbecaf8c98397
   languageName: node
   linkType: hard
 
@@ -15371,7 +15168,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.7, node-fetch@npm:^2.6.1":
+"node-fetch@npm:2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:
@@ -15776,15 +15573,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"one-time@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "one-time@npm:1.0.0"
-  dependencies:
-    fn.name: 1.x.x
-  checksum: fd008d7e992bdec1c67f53a2f9b46381ee12a9b8c309f88b21f0223546003fb47e8ad7c1fd5843751920a8d276c63bd4b45670ef80c61fb3e07dbccc962b5c7d
-  languageName: node
-  linkType: hard
-
 "onetime@npm:^5.1.0, onetime@npm:^5.1.2":
   version: 5.1.2
   resolution: "onetime@npm:5.1.2"
@@ -15794,7 +15582,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"open@npm:8.4.0, open@npm:^8.0.0, open@npm:^8.0.9, open@npm:^8.4.0":
+"open@npm:8.4.0, open@npm:^8.0.9, open@npm:^8.4.0":
   version: 8.4.0
   resolution: "open@npm:8.4.0"
   dependencies:
@@ -15851,7 +15639,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ora@npm:5.4.1, ora@npm:^5.1.0, ora@npm:^5.3.0, ora@npm:^5.4.1":
+"ora@npm:5.4.1, ora@npm:^5.1.0, ora@npm:^5.4.1":
   version: 5.4.1
   resolution: "ora@npm:5.4.1"
   dependencies:
@@ -16166,7 +15954,6 @@ __metadata:
     "@angular/compiler": 15.1.2
     "@angular/compiler-cli": 15.1.2
     "@angular/core": 15.1.2
-    "@angular/fire": ^7.3.0
     "@angular/forms": 15.1.2
     "@angular/language-service": 15.1.2
     "@angular/material": 15.1.2
@@ -17991,19 +17778,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxfire@npm:^6.0.0":
-  version: 6.0.3
-  resolution: "rxfire@npm:6.0.3"
-  dependencies:
-    tslib: ^1.9.0 || ~2.1.0
-  peerDependencies:
-    firebase: ^9.0.0
-    rxjs: ^6.0.0 || ^7.0.0
-  checksum: 418ccf6ee9553fca2e6b0d65099903d82b45a0b1eb4487211dcf5319caf26454f84e9c8834bc932289c7e09e14fc39385188f046568a7c2364735a3135c320fb
-  languageName: node
-  linkType: hard
-
-"rxjs@npm:6.6.7, rxjs@npm:^6.5.4, rxjs@npm:^6.6.2":
+"rxjs@npm:6.6.7, rxjs@npm:^6.5.4":
   version: 6.6.7
   resolution: "rxjs@npm:6.6.7"
   dependencies:
@@ -18057,13 +17832,6 @@ __metadata:
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
-  languageName: node
-  linkType: hard
-
-"safe-stable-stringify@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "safe-stable-stringify@npm:2.3.1"
-  checksum: a0a0bad0294c3e2a9d1bf3cf2b1096dfb83c162d09a5e4891e488cce082120bd69161d2a92aae7fc48255290f17700decae9c89a07fe139794e61b5c8b411377
   languageName: node
   linkType: hard
 
@@ -18275,7 +18043,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.x, semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.1.3, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7":
+"semver@npm:7.x, semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7":
   version: 7.3.7
   resolution: "semver@npm:7.3.7"
   dependencies:
@@ -18663,17 +18431,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:0.7.3, source-map@npm:^0.7.3":
-  version: 0.7.3
-  resolution: "source-map@npm:0.7.3"
-  checksum: cd24efb3b8fa69b64bf28e3c1b1a500de77e84260c5b7f2b873f88284df17974157cc88d386ee9b6d081f08fdd8242f3fc05c953685a6ad81aad94c7393dedea
-  languageName: node
-  linkType: hard
-
 "source-map@npm:0.7.4, source-map@npm:^0.7.4":
   version: 0.7.4
   resolution: "source-map@npm:0.7.4"
   checksum: 01cc5a74b1f0e1d626a58d36ad6898ea820567e87f18dfc9d24a9843a351aaa2ec09b87422589906d6ff1deed29693e176194dc88bcae7c9a852dc74b311dbf5
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.7.3":
+  version: 0.7.3
+  resolution: "source-map@npm:0.7.3"
+  checksum: cd24efb3b8fa69b64bf28e3c1b1a500de77e84260c5b7f2b873f88284df17974157cc88d386ee9b6d081f08fdd8242f3fc05c953685a6ad81aad94c7393dedea
   languageName: node
   linkType: hard
 
@@ -18811,13 +18579,6 @@ __metadata:
   dependencies:
     stackframe: ^1.3.4
   checksum: 4fc3978a934424218a0aa9f398034e1f78153d5ff4f4ff9c62478c672debb47dd58de05b09fc3900530cbb526d72c93a6e6c9353bacc698e3b1c00ca3dda0c47
-  languageName: node
-  linkType: hard
-
-"stack-trace@npm:0.0.x":
-  version: 0.0.10
-  resolution: "stack-trace@npm:0.0.10"
-  checksum: 473036ad32f8c00e889613153d6454f9be0536d430eb2358ca51cad6b95cea08a3cc33cc0e34de66b0dad221582b08ed2e61ef8e13f4087ab690f388362d6610
   languageName: node
   linkType: hard
 
@@ -19279,13 +19040,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"text-hex@npm:1.0.x":
-  version: 1.0.0
-  resolution: "text-hex@npm:1.0.0"
-  checksum: 1138f68adc97bf4381a302a24e2352f04992b7b1316c5003767e9b0d3367ffd0dc73d65001ea02b07cd0ecc2a9d186de0cf02f3c2d880b8a522d4ccb9342244a
-  languageName: node
-  linkType: hard
-
 "text-segmentation@npm:^1.0.3":
   version: 1.0.3
   resolution: "text-segmentation@npm:1.0.3"
@@ -19426,13 +19180,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"triple-beam@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "triple-beam@npm:1.3.0"
-  checksum: 7d7b77d8625fb252c126c24984a68de462b538a8fcd1de2abd0a26421629cf3527d48e23b3c2264f08f4a6c3bc40a478a722176f4d7b6a1acc154cb70c359f2b
-  languageName: node
-  linkType: hard
-
 "ts-jest@npm:28.0.5, ts-jest@npm:^28.0.0":
   version: 28.0.5
   resolution: "ts-jest@npm:28.0.5"
@@ -19549,13 +19296,6 @@ __metadata:
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^1.9.0 || ~2.1.0":
-  version: 2.1.0
-  resolution: "tslib@npm:2.1.0"
-  checksum: aa189c8179de0427b0906da30926fd53c59d96ec239dff87d6e6bc831f608df0cbd6f77c61dabc074408bd0aa0b9ae4ec35cb2c15f729e32f37274db5730cb78
   languageName: node
   linkType: hard
 
@@ -19762,7 +19502,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"universalify@npm:^0.1.0, universalify@npm:^0.1.2":
+"universalify@npm:^0.1.2":
   version: 0.1.2
   resolution: "universalify@npm:0.1.2"
   checksum: 40cdc60f6e61070fe658ca36016a8f4ec216b29bf04a55dce14e3710cc84c7448538ef4dad3728d0bfe29975ccd7bfb5f414c45e7b78883567fb31b246f02dff
@@ -20300,35 +20040,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"winston-transport@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "winston-transport@npm:4.5.0"
-  dependencies:
-    logform: ^2.3.2
-    readable-stream: ^3.6.0
-    triple-beam: ^1.3.0
-  checksum: a56e5678a80b88a73e77ed998fc6e19d0db19c989a356b137ec236782f2bf58ae4511b11c29163f99391fa4dc12102c7bc5738dcb6543f28877fa2819adc3ee9
-  languageName: node
-  linkType: hard
-
-"winston@npm:^3.0.0":
-  version: 3.7.2
-  resolution: "winston@npm:3.7.2"
-  dependencies:
-    "@dabh/diagnostics": ^2.0.2
-    async: ^3.2.3
-    is-stream: ^2.0.0
-    logform: ^2.4.0
-    one-time: ^1.0.0
-    readable-stream: ^3.4.0
-    safe-stable-stringify: ^2.3.1
-    stack-trace: 0.0.x
-    triple-beam: ^1.3.0
-    winston-transport: ^4.5.0
-  checksum: f1f1a860d2fa228b50880b20aaa6cc121085907791fe0d814ff9c062640f6b65da321726322094e7667eb63088b3bb67e7b4e219d998f29efcc6f583185a1cd3
-  languageName: node
-  linkType: hard
-
 "word-wrap@npm:^1.2.3, word-wrap@npm:~1.2.3":
   version: 1.2.3
   resolution: "word-wrap@npm:1.2.3"
@@ -20405,7 +20116,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:>=7.4.6, ws@npm:^8.4.2":
+"ws@npm:>=7.4.6":
+  version: 8.12.0
+  resolution: "ws@npm:8.12.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 818ff3f8749c172a95a114cceb8b89cedd27e43a82d65c7ad0f7882b1e96a2ee6709e3746a903c3fa88beec0c8bae9a9fcd75f20858b32a166dfb7519316a5d7
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.4.2":
   version: 8.7.0
   resolution: "ws@npm:8.7.0"
   peerDependencies:


### PR DESCRIPTION
## Description

When updating angular v15 many of the angular-fire methods broke. Attempting to fix the various incompatibilities proved too difficult (still various open issues on angular/fire repo not resolved more than 2 months after v15 release). So instead dropping angular/fire for using the firebase SDK directly.

Also includes updating all firebase methods to the v9 syntax