### PR TITLE
feat: add support for gender decision and activities

### DIFF
--- a/apps/picsa-tools/option-tool/src/app/components/components.module.ts
+++ b/apps/picsa-tools/option-tool/src/app/components/components.module.ts
@@ -8,9 +8,10 @@ import { PicsaTranslateModule } from '@picsa/shared/modules';
 
 // Local components
 import { EditorComponent } from './editor/editor.component';
+import { GenderIconComponent } from './gender-icon/gender-icon.component';
 import { OptionMaterialModule } from './material.module';
 
-const Components = [EditorComponent];
+const Components = [EditorComponent, GenderIconComponent];
 
 @NgModule({
   imports: [

--- a/apps/picsa-tools/option-tool/src/app/components/editor/editor.component.html
+++ b/apps/picsa-tools/option-tool/src/app/components/editor/editor.component.html
@@ -259,7 +259,7 @@
             <div class="performenceItem">
               <div style="font-weight: 700; display: flex; flex-direction: row; justify-content: space-between">
                 {{ 'Money' | translate }}
-                <mat-icon style="color: #8a2644; font-size: 20px">attach_money</mat-icon>
+                <mat-icon style="color: #8a2644; font-size: 20px">payments</mat-icon>
               </div>
               <select
                 style="width: 5rem; height: 2rem; font-size: 14px; margin-top: 9px; outline-color: #8a2644"
@@ -273,7 +273,7 @@
             <div class="performenceItem">
               <div style="font-weight: 700; display: flex; flex-direction: row; justify-content: space-between">
                 {{ 'Time' | translate }}
-                <mat-icon style="color: #8a2644; font-size: 20px">access_time</mat-icon>
+                <mat-icon style="color: #8a2644; font-size: 20px">schedule</mat-icon>
               </div>
               <select
                 style="width: 5rem; height: 2rem; font-size: 14px; margin-top: 9px; outline-color: #8a2644"

--- a/apps/picsa-tools/option-tool/src/app/components/editor/editor.component.html
+++ b/apps/picsa-tools/option-tool/src/app/components/editor/editor.component.html
@@ -11,16 +11,16 @@
         <div class="StepContent">
           <div class="form-group">
             <label>{{ 'Practice' | translate }}</label>
-            <input [(ngModel)]="practiceEntry" class="form-control" />
+            <input [(ngModel)]="values.practice" class="form-control" />
           </div>
           <div class="importantText">{{ '*This field is required' | translate }}</div>
         </div>
         <div>
-          <button mat-raised-button color="primary" [disabled]="!practiceEntry" matStepperNext>
+          <button mat-raised-button color="primary" [disabled]="!values.practice" matStepperNext>
             {{ 'Next' | translate }}
           </button>
         </div>
-        <button mat-stroked-button style="margin-top: 3em" (click)="promptDelete()" [disabled]="!practiceEntry">
+        <button mat-stroked-button style="margin-top: 3em" (click)="promptDelete()" [disabled]="!values.practice">
           <mat-icon name="delete">delete</mat-icon> {{ 'Delete' | translate }}
         </button>
       </div>
@@ -28,17 +28,17 @@
 
     <!-- Who does it -->
     <mat-step matStepContent>
-      <ng-template matStepLabel>{{ 'Gender' | translate }}</ng-template>
+      <ng-template matStepLabel>{{ 'Decisions' | translate }}</ng-template>
       <div class="StepContainer">
-        <div class="StepTitle">{{ 'Who does the practice' | translate }}?</div>
+        <div class="StepTitle">{{ 'Who makes decisions' | translate }}?</div>
         <div class="StepContent">
           <div class="genderDiv">
             <div
               class="genderType"
               style="color: #800080"
-              (click)="handleGender('female')"
+              (click)="handleGender('female', 'gender_decisions')"
               [ngStyle]="{
-                'background-color': gender.includes('female') ? 'wheat' : 'lightgray'
+                'background-color': values.gender_decisions.includes('female') ? 'wheat' : 'lightgray'
               }"
             >
               {{ 'Female' | translate }}
@@ -46,10 +46,10 @@
             </div>
             <div
               class="genderType"
-              (click)="handleGender('male')"
+              (click)="handleGender('male', 'gender_decisions')"
               style="color: #008066"
               [ngStyle]="{
-                'background-color': gender.includes('male') ? 'wheat' : 'lightgray'
+                'background-color': values.gender_decisions.includes('male') ? 'wheat' : 'lightgray'
               }"
             >
               {{ 'Male' | translate }}
@@ -57,12 +57,59 @@
             </div>
           </div>
           <div style="height: 1rem">
-            {{ gender.length > 1 ? gender.join(' and ') : gender[0] }}
+            {{
+              values.gender_decisions.length > 1 ? values.gender_decisions.join(' and ') : values.gender_decisions[0]
+            }}
           </div>
         </div>
         <div class="ButtonSection">
           <button mat-button matStepperPrevious>{{ 'Back' | translate }}</button>
-          <button mat-raised-button color="primary" [disabled]="!(gender.length > 0)" matStepperNext>
+          <button mat-raised-button color="primary" [disabled]="!(values.gender_decisions.length > 0)" matStepperNext>
+            {{ 'Next' | translate }}
+          </button>
+        </div>
+      </div>
+    </mat-step>
+
+    <!-- Who does it -->
+    <mat-step matStepContent>
+      <ng-template matStepLabel>{{ 'Activities' | translate }}</ng-template>
+      <div class="StepContainer">
+        <div class="StepTitle">{{ 'Who does the activity' | translate }}?</div>
+        <div class="StepContent">
+          <div class="genderDiv">
+            <div
+              class="genderType"
+              style="color: #800080"
+              (click)="handleGender('female', 'gender_activities')"
+              [ngStyle]="{
+                'background-color': values.gender_activities.includes('female') ? 'wheat' : 'lightgray'
+              }"
+            >
+              {{ 'Female' | translate }}
+              <mat-icon svgIcon="picsa_options_female"></mat-icon>
+            </div>
+            <div
+              class="genderType"
+              (click)="handleGender('male', 'gender_activities')"
+              style="color: #008066"
+              [ngStyle]="{
+                'background-color': values.gender_activities.includes('male') ? 'wheat' : 'lightgray'
+              }"
+            >
+              {{ 'Male' | translate }}
+              <mat-icon svgIcon="picsa_options_male"></mat-icon>
+            </div>
+          </div>
+          <div style="height: 1rem">
+            {{
+              values.gender_activities.length > 1 ? values.gender_activities.join(' and ') : values.gender_activities[0]
+            }}
+          </div>
+        </div>
+        <div class="ButtonSection">
+          <button mat-button matStepperPrevious>{{ 'Back' | translate }}</button>
+          <button mat-raised-button color="primary" [disabled]="!(values.gender_activities.length > 0)" matStepperNext>
             {{ 'Next' | translate }}
           </button>
         </div>
@@ -76,7 +123,7 @@
         <div class="StepTitle">{{ 'Benefits and who ' | translate }} ?</div>
         <div class="StepContent">
           <div style="margin-bottom: 1.5rem; padding: 2px; margin-top: 2rem">
-            <div *ngFor="let benefit of benefits; index as i">
+            <div *ngFor="let benefit of values.benefits; index as i">
               <div style="display: flex; flex-direction: row; gap: 3px; padding-bottom: 3px">
                 <textarea [(ngModel)]="benefit.benefit" class="form-control"></textarea>
                 <div
@@ -105,7 +152,7 @@
                   mat-button
                   color="primary"
                   (click)="handleRemovingBenefits(i)"
-                  [disabled]="!benefits[i] || !benefits[i].benefit"
+                  [disabled]="!values.benefits[i] || !values.benefits[i].benefit"
                 >
                   <mat-icon>close</mat-icon>
                 </button>
@@ -118,7 +165,7 @@
         </div>
         <div class="ButtonSection">
           <button matStepperPrevious mat-button>{{ 'Back' | translate }}</button>
-          <button mat-raised-button color="primary" [disabled]="!(benefits.length > 0)" matStepperNext>
+          <button mat-raised-button color="primary" [disabled]="!(values.benefits.length > 0)" matStepperNext>
             {{ 'Next' | translate }}
           </button>
         </div>
@@ -147,7 +194,7 @@
               <div style="font-weight: 700">{{ 'High RF' | translate }}</div>
               <select
                 style="width: 5rem; height: 2rem; font-size: 14px; margin-top: 5px; outline-color: #8a2644"
-                [(ngModel)]="perfomanceValues.highRf"
+                [(ngModel)]="values.performance.highRf"
               >
                 <option *ngFor="let option of performanceOptions" [value]="option">
                   {{ option }}
@@ -158,7 +205,7 @@
               <div style="font-weight: 700">{{ 'Mid RF' | translate }}</div>
               <select
                 style="width: 5rem; height: 2rem; font-size: 14px; margin-top: 5px; outline-color: #8a2644"
-                [(ngModel)]="perfomanceValues.midRf"
+                [(ngModel)]="values.performance.midRf"
               >
                 <option *ngFor="let option of performanceOptions" [value]="option">
                   {{ option }}
@@ -169,7 +216,7 @@
               <div style="font-weight: 700">{{ 'Low RF' | translate }}</div>
               <select
                 style="width: 5rem; height: 2rem; font-size: 14px; margin-top: 5px; outline-color: #8a2644"
-                [(ngModel)]="perfomanceValues.lowRf"
+                [(ngModel)]="values.performance.lowRf"
               >
                 <option *ngFor="let option of performanceOptions" [value]="option">
                   {{ option }}
@@ -183,7 +230,7 @@
           <button
             mat-raised-button
             color="primary"
-            [disabled]="!(perfomanceValues.lowRf && perfomanceValues.midRf && perfomanceValues.highRf)"
+            [disabled]="!(values.performance.lowRf && values.performance.midRf && values.performance.highRf)"
             matStepperNext
           >
             {{ 'Next' | translate }}
@@ -216,7 +263,7 @@
               </div>
               <select
                 style="width: 5rem; height: 2rem; font-size: 14px; margin-top: 9px; outline-color: #8a2644"
-                [(ngModel)]="investmentValues.money"
+                [(ngModel)]="values.investment.money"
               >
                 <option *ngFor="let option of investmentOptions" [value]="option">
                   {{ option }}
@@ -230,7 +277,7 @@
               </div>
               <select
                 style="width: 5rem; height: 2rem; font-size: 14px; margin-top: 9px; outline-color: #8a2644"
-                [(ngModel)]="investmentValues.time"
+                [(ngModel)]="values.investment.time"
               >
                 <option *ngFor="let option of investmentOptions" [value]="option">
                   {{ option }}
@@ -244,7 +291,7 @@
           <button
             mat-raised-button
             color="primary"
-            [disabled]="!(investmentValues.money && investmentValues.time)"
+            [disabled]="!(values.investment.money && values.investment.time)"
             matStepperNext
           >
             {{ 'Next' | translate }}
@@ -265,12 +312,12 @@
               (months)' | translate }}
               <mat-icon style="color: #8a2644; font-size: 20px">date_range</mat-icon></label
             >
-            <input [(ngModel)]="benefitsStartTime" (keypress)="onlyNumbers($event)" class="form-control" />
+            <input [(ngModel)]="values.time" (keypress)="onlyNumbers($event)" class="form-control" />
           </div>
         </div>
         <div class="ButtonSection">
           <button matStepperPrevious mat-button>{{ 'Back' | translate }}</button>
-          <button mat-raised-button color="primary" [disabled]="!benefitsStartTime" matStepperNext>
+          <button mat-raised-button color="primary" [disabled]="!values.time" matStepperNext>
             {{ 'Next' | translate }}
           </button>
         </div>
@@ -287,12 +334,12 @@
             <label style="font-weight: 700; display: flex; flex-direction: row; justify-content: space-between"
               >{{ 'Risk' | translate }}<mat-icon style="color: #e71236; font-size: 20px">warning</mat-icon></label
             >
-            <input style="margin-left: 4px" [(ngModel)]="risk" class="form-control" />
+            <input style="margin-left: 4px" [(ngModel)]="values.risk" class="form-control" />
           </div>
         </div>
         <div class="ButtonSection">
           <button matStepperPrevious mat-button>{{ 'Back' | translate }}</button>
-          <button mat-raised-button color="primary" [disabled]="!risk" (click)="submitForm()">
+          <button mat-raised-button color="primary" [disabled]="!values.risk" (click)="submitForm()">
             {{ 'Finish' | translate }}
           </button>
         </div>

--- a/apps/picsa-tools/option-tool/src/app/components/editor/editor.component.ts
+++ b/apps/picsa-tools/option-tool/src/app/components/editor/editor.component.ts
@@ -10,7 +10,7 @@ import { ENTRY_TEMPLATE, IOptionsToolEntry } from '../../schemas';
   styleUrls: ['./editor.component.scss'],
 })
 export class EditorComponent {
-  values = ENTRY_TEMPLATE;
+  values = ENTRY_TEMPLATE();
 
   performanceOptions: string[] = ['good', 'ok', 'bad'];
   investmentOptions: string[] = ['high', 'mid', 'low'];
@@ -67,7 +67,7 @@ export class EditorComponent {
     this.resetStepper();
   }
   resetVariables() {
-    this.values = JSON.parse(JSON.stringify(ENTRY_TEMPLATE));
+    this.values = ENTRY_TEMPLATE();
   }
   //incase of edits
   presetVariables(rowData: IOptionsToolEntry) {

--- a/apps/picsa-tools/option-tool/src/app/components/editor/editor.component.ts
+++ b/apps/picsa-tools/option-tool/src/app/components/editor/editor.component.ts
@@ -1,77 +1,48 @@
-import { Component, EventEmitter, OnInit, Output, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Output, ViewChild } from '@angular/core';
 import { MatStepper } from '@angular/material/stepper';
 import { PicsaDialogService } from '@picsa/shared/features';
 
-export interface IOptionData {
-  practice: string;
-  gender: string[];
-  benefits: { benefit: string; beneficiary: string[] }[];
-  performance: { lowRf: string; midRf: string; highRf: string };
-  investment: { money: string; time: string };
-  time: string;
-  risk: string;
-}
+import { ENTRY_TEMPLATE, IOptionsToolEntry } from '../../schemas';
+
 @Component({
   selector: 'option-editor',
   templateUrl: './editor.component.html',
   styleUrls: ['./editor.component.scss'],
 })
-export class EditorComponent implements OnInit {
-  practiceEntry: string;
-  gender: string[];
-  benefits: { benefit: string; beneficiary: string[] }[];
-  perfomanceValues: { lowRf: string; midRf: string; highRf: string };
+export class EditorComponent {
+  values = ENTRY_TEMPLATE;
+
   performanceOptions: string[] = ['good', 'ok', 'bad'];
-  investmentValues: { money: string; time: string };
   investmentOptions: string[] = ['high', 'mid', 'low'];
-  benefitsStartTime: string;
-  risk: string;
   isLinear = false;
 
   @ViewChild(MatStepper) stepper: MatStepper;
-  @Output() dataTransfer = new EventEmitter<IOptionData | null>();
+  @Output() dataTransfer = new EventEmitter<IOptionsToolEntry | null>();
 
   constructor(private dialog: PicsaDialogService) {}
 
-  ngOnInit(): void {
-    this.gender = [];
-    this.benefits = [
-      {
-        benefit: '',
-        beneficiary: [],
-      },
-    ];
-    this.perfomanceValues = { lowRf: 'ok', midRf: 'ok', highRf: 'ok' };
-    this.investmentValues = { money: 'high', time: 'high' };
-    this.practiceEntry = '';
-    this.gender = [];
-    this.perfomanceValues = { lowRf: '', midRf: '', highRf: '' };
-    this.investmentValues = { money: '', time: '' };
-    this.benefitsStartTime = '';
-    this.risk = '';
-  }
-
-  handleGender(gender: string) {
-    if (!this.gender.includes(gender)) {
-      this.gender.push(gender);
+  handleGender(gender: string, field: 'gender_activities' | 'gender_decisions') {
+    console.log('handle gender', { gender, field }, this.values[field]);
+    if (!this.values[field].includes(gender)) {
+      this.values[field].push(gender);
     } else {
-      const index = this.gender.indexOf(gender);
-      this.gender.splice(index, 1);
+      const index = this.values[field].indexOf(gender);
+      this.values[field].splice(index, 1);
     }
   }
   handleBenficiaryGender(index: number, gender: string) {
-    if (!this.benefits[index].beneficiary.includes(gender)) {
-      this.benefits[index].beneficiary.push(gender);
+    if (!this.values.benefits[index].beneficiary.includes(gender)) {
+      this.values.benefits[index].beneficiary.push(gender);
     } else {
-      const itemIndex = this.benefits[index].beneficiary.indexOf(gender);
-      this.benefits[index].beneficiary.splice(itemIndex, 1);
+      const itemIndex = this.values.benefits[index].beneficiary.indexOf(gender);
+      this.values.benefits[index].beneficiary.splice(itemIndex, 1);
     }
   }
   handleRemovingBenefits(index: number) {
-    this.benefits.splice(index, 1);
+    this.values.benefits.splice(index, 1);
   }
   handleMoreBenefits() {
-    this.benefits.push({
+    this.values.benefits.push({
       benefit: '',
       beneficiary: [],
     });
@@ -87,50 +58,20 @@ export class EditorComponent implements OnInit {
 
   async submitForm() {
     // minimum for auto save should be at least a name
-    if (!this.practiceEntry) {
+    if (!this.values.practice) {
       this.dataTransfer.emit(null);
       return;
     }
-    const data: IOptionData = {
-      practice: this.practiceEntry,
-      gender: this.gender,
-      benefits: this.benefits,
-      performance: this.perfomanceValues,
-      investment: this.investmentValues,
-      time: this.benefitsStartTime,
-      risk: this.risk,
-    };
-    this.dataTransfer.emit(data);
+    this.dataTransfer.emit(this.values);
     this.resetVariables();
     this.resetStepper();
   }
   resetVariables() {
-    // Reset variables when the component is destroyed.
-    this.gender = [];
-    this.benefits = [
-      {
-        benefit: '',
-        beneficiary: [],
-      },
-    ];
-    this.perfomanceValues = { lowRf: 'ok', midRf: 'ok', highRf: 'ok' };
-    this.investmentValues = { money: 'high', time: 'high' };
-    this.practiceEntry = '';
-    this.gender = [];
-    this.perfomanceValues = { lowRf: '', midRf: '', highRf: '' };
-    this.investmentValues = { money: '', time: '' };
-    this.benefitsStartTime = '';
-    this.risk = '';
+    this.values = JSON.parse(JSON.stringify(ENTRY_TEMPLATE));
   }
   //incase of edits
-  presetVariables(rowData: IOptionData) {
-    this.benefits = rowData.benefits;
-    this.perfomanceValues = rowData.performance;
-    this.investmentValues = rowData.investment;
-    this.practiceEntry = rowData.practice;
-    this.gender = rowData.gender;
-    this.benefitsStartTime = rowData.time;
-    this.risk = rowData.risk;
+  presetVariables(rowData: IOptionsToolEntry) {
+    this.values = rowData;
   }
   resetStepper(): void {
     this.stepper.reset();

--- a/apps/picsa-tools/option-tool/src/app/components/gender-icon/gender-icon.component.html
+++ b/apps/picsa-tools/option-tool/src/app/components/gender-icon/gender-icon.component.html
@@ -1,0 +1,4 @@
+<div class="gender-container">
+  <mat-icon [svgIcon]="'picsa_options_' + gender"></mat-icon>
+  <div class="gender-label" *ngIf="showLabel">{{ gender | translate }}</div>
+</div>

--- a/apps/picsa-tools/option-tool/src/app/components/gender-icon/gender-icon.component.scss
+++ b/apps/picsa-tools/option-tool/src/app/components/gender-icon/gender-icon.component.scss
@@ -1,0 +1,8 @@
+.gender-container {
+  display: flex;
+  align-items: center;
+  margin: 4px 0;
+}
+.gender-label {
+  text-transform: capitalize;
+}

--- a/apps/picsa-tools/option-tool/src/app/components/gender-icon/gender-icon.component.spec.ts
+++ b/apps/picsa-tools/option-tool/src/app/components/gender-icon/gender-icon.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GenderIconComponent } from './gender-icon.component';
+
+describe('GenderIconComponent', () => {
+  let component: GenderIconComponent;
+  let fixture: ComponentFixture<GenderIconComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [GenderIconComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GenderIconComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/picsa-tools/option-tool/src/app/components/gender-icon/gender-icon.component.ts
+++ b/apps/picsa-tools/option-tool/src/app/components/gender-icon/gender-icon.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'picsa-gender-icon',
+  templateUrl: './gender-icon.component.html',
+  styleUrls: ['./gender-icon.component.scss'],
+})
+export class GenderIconComponent {
+  @Input() gender: 'male' | 'female';
+  @Input() showLabel = true;
+}

--- a/apps/picsa-tools/option-tool/src/app/pages/home/home.component.html
+++ b/apps/picsa-tools/option-tool/src/app/pages/home/home.component.html
@@ -13,25 +13,46 @@
       <!-- gender decisions Column -->
       <ng-container matColumnDef="gender_decisions">
         <th mat-header-cell *matHeaderCellDef>{{ 'Who makes decisions' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element._data.gender_decisions.join(',') | translate }}</td>
+        <td mat-cell *matCellDef="let element">
+          <picsa-gender-icon
+            *ngFor="let gender of element._data.gender_decisions"
+            [gender]="gender"
+          ></picsa-gender-icon>
+        </td>
       </ng-container>
 
       <!-- gender activities Column -->
       <ng-container matColumnDef="gender_activities">
         <th mat-header-cell *matHeaderCellDef>{{ 'Who does activity' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element._data.gender_activities.join(',') | translate }}</td>
+        <td mat-cell *matCellDef="let element">
+          <picsa-gender-icon
+            *ngFor="let gender of element._data.gender_activities"
+            [gender]="gender"
+          ></picsa-gender-icon>
+        </td>
       </ng-container>
 
       <!-- Benefits Column -->
       <ng-container matColumnDef="benefits">
         <th mat-header-cell *matHeaderCellDef>{{ 'Benefits and who' | translate }}</th>
         <td mat-cell *matCellDef="let element">
-          <ol *ngFor="let benefit of element._data.benefits; index as i">
-            <li>
-              {{ benefit.benefit }}
-              <div>{{ benefit.beneficiary.join(',') }}</div>
-            </li>
-          </ol>
+          <div *ngFor="let benefit of element._data.benefits; index as i" class="benefit-container">
+            <div style="flex: 1">{{ benefit.benefit }}</div>
+            <div style="display: flex; width: 50px">
+              <!-- HACK add placeholder for both female and male to align, but hide if not used -->
+              <picsa-gender-icon
+                gender="female"
+                [showLabel]="false"
+                [style.visibility]="benefit.beneficiary.includes('female') ? 'visible' : 'hidden'"
+              ></picsa-gender-icon>
+
+              <picsa-gender-icon
+                gender="male"
+                [showLabel]="false"
+                [style.visibility]="benefit.beneficiary.includes('male') ? 'visible' : 'hidden'"
+              ></picsa-gender-icon>
+            </div>
+          </div>
         </td>
       </ng-container>
 
@@ -51,10 +72,15 @@
       <ng-container matColumnDef="investment">
         <th mat-header-cell *matHeaderCellDef>{{ 'Investment' | translate }}</th>
         <td mat-cell *matCellDef="let element">
-          <ol style="display: flex; flex-direction: column; gap: 3px">
-            <li>{{ 'Money' | translate }} : {{ element._data.investment.money | translate }}</li>
-            <li>{{ 'Time' | translate }} : {{ element._data.investment.time | translate }}</li>
-          </ol>
+          <div>
+            <mat-icon>payments</mat-icon>
+            <span style="margin-left: 8px">{{ element._data.investment.money | translate }}</span>
+          </div>
+
+          <div style="margin-top: 1rem">
+            <mat-icon>schedule</mat-icon>
+            <span style="margin-left: 8px">{{ element._data.investment.time | translate }}</span>
+          </div>
         </td>
       </ng-container>
 

--- a/apps/picsa-tools/option-tool/src/app/pages/home/home.component.html
+++ b/apps/picsa-tools/option-tool/src/app/pages/home/home.component.html
@@ -10,10 +10,16 @@
         <td mat-cell *matCellDef="let element">{{ element._data.practice | translate }}</td>
       </ng-container>
 
-      <!-- gender Column -->
-      <ng-container matColumnDef="gender">
-        <th mat-header-cell *matHeaderCellDef>{{ 'Who does it' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element._data.gender.join(',') | translate }}</td>
+      <!-- gender decisions Column -->
+      <ng-container matColumnDef="gender_decisions">
+        <th mat-header-cell *matHeaderCellDef>{{ 'Who makes decisions' | translate }}</th>
+        <td mat-cell *matCellDef="let element">{{ element._data.gender_decisions.join(',') | translate }}</td>
+      </ng-container>
+
+      <!-- gender activities Column -->
+      <ng-container matColumnDef="gender_activities">
+        <th mat-header-cell *matHeaderCellDef>{{ 'Who does activity' | translate }}</th>
+        <td mat-cell *matCellDef="let element">{{ element._data.gender_activities.join(',') | translate }}</td>
       </ng-container>
 
       <!-- Benefits Column -->

--- a/apps/picsa-tools/option-tool/src/app/pages/home/home.component.scss
+++ b/apps/picsa-tools/option-tool/src/app/pages/home/home.component.scss
@@ -6,6 +6,12 @@ th {
   border: 1px solid black;
   padding: 8px;
 }
+td {
+  vertical-align: top;
+}
+td.mdc-data-table__cell {
+  padding: 8px;
+}
 
 .HomeContainer {
   max-height: 100vh;
@@ -46,4 +52,10 @@ th {
 .slide-in.active {
   transform: translateY(0);
   display: block;
+}
+
+.benefit-container {
+  display: flex;
+  margin-bottom: 8px;
+  align-items: center;
 }

--- a/apps/picsa-tools/option-tool/src/app/pages/home/home.component.ts
+++ b/apps/picsa-tools/option-tool/src/app/pages/home/home.component.ts
@@ -7,8 +7,6 @@ import { EditorComponent } from '../../components/editor/editor.component';
 import { ENTRY_TEMPLATE, IOptionsToolEntry } from '../../schemas';
 import { OptionsToolService } from '../../services/options-tool.service';
 
-const { _app_user_id, ...DISPLAYED_COLUMNS } = ENTRY_TEMPLATE;
-
 @Component({
   selector: 'option-home',
   templateUrl: './home.component.html',
@@ -16,7 +14,9 @@ const { _app_user_id, ...DISPLAYED_COLUMNS } = ENTRY_TEMPLATE;
 })
 export class HomeComponent implements OnDestroy {
   public optionsDisplayList: IOptionsToolEntry[] = [];
-  public displayedColumns = Object.keys(DISPLAYED_COLUMNS);
+
+  /** List of columns to display in table. Note, order will match template keys */
+  public displayedColumns = Object.keys(ENTRY_TEMPLATE()).filter((key) => !key.startsWith('_'));
 
   public dbDataDocs: RxDocument<IOptionsToolEntry>[] = [];
   public matStepperOpen = false;

--- a/apps/picsa-tools/option-tool/src/app/pages/home/home.component.ts
+++ b/apps/picsa-tools/option-tool/src/app/pages/home/home.component.ts
@@ -4,8 +4,10 @@ import { Subject, takeUntil } from 'rxjs';
 
 // import { Observable } from 'rxjs';
 import { EditorComponent } from '../../components/editor/editor.component';
-import { IOptionsToolEntry } from '../../schemas';
+import { ENTRY_TEMPLATE, IOptionsToolEntry } from '../../schemas';
 import { OptionsToolService } from '../../services/options-tool.service';
+
+const { _app_user_id, ...DISPLAYED_COLUMNS } = ENTRY_TEMPLATE;
 
 @Component({
   selector: 'option-home',
@@ -14,7 +16,7 @@ import { OptionsToolService } from '../../services/options-tool.service';
 })
 export class HomeComponent implements OnDestroy {
   public optionsDisplayList: IOptionsToolEntry[] = [];
-  public displayedColumns: string[] = ['practice', 'gender', 'benefits', 'performance', 'investment', 'time', 'risk'];
+  public displayedColumns = Object.keys(DISPLAYED_COLUMNS);
 
   public dbDataDocs: RxDocument<IOptionsToolEntry>[] = [];
   public matStepperOpen = false;

--- a/apps/picsa-tools/option-tool/src/app/pages/home/home.component.ts
+++ b/apps/picsa-tools/option-tool/src/app/pages/home/home.component.ts
@@ -55,14 +55,7 @@ export class HomeComponent implements OnDestroy {
   }
   async onDataTransfer(data: IOptionsToolEntry | null) {
     if (data) {
-      //when the name changes, incrementalUpsert is not enough since the name is the primary key
-      if (this.dbDataDocs[this.editorIndex] && this.dbDataDocs[this.editorIndex]._data.practice !== data.practice) {
-        //delete old option and add new option
-        await this.service.addORUpdateData(data);
-        await this.service.deleteOption(this.dbDataDocs[this.editorIndex]);
-      } else {
-        await this.service.addORUpdateData(data);
-      }
+      await this.service.addORUpdateData(data);
     } else {
       // remove any existing entry entry if no data passed back
       //delete from db

--- a/apps/picsa-tools/option-tool/src/app/schemas/index.ts
+++ b/apps/picsa-tools/option-tool/src/app/schemas/index.ts
@@ -1,7 +1,9 @@
-import { COLLECTION_V1, IOptionsToolEntry_v1, SCHEMA_V1 } from './schema_v1';
+import { COLLECTION_V2, ENTRY_TEMPLATE_V2, IOptionsToolEntry_v2, SCHEMA_V2 } from './schema_v2';
 
 // Re-export schema to provide latest version without need to refactor additonal code
 
-export const COLLECTION = COLLECTION_V1;
-export type IOptionsToolEntry = IOptionsToolEntry_v1;
-export const SCHEMA = SCHEMA_V1;
+export const COLLECTION = COLLECTION_V2;
+export type IOptionsToolEntry = IOptionsToolEntry_v2;
+export const SCHEMA = SCHEMA_V2;
+
+export const ENTRY_TEMPLATE = ENTRY_TEMPLATE_V2;

--- a/apps/picsa-tools/option-tool/src/app/schemas/index.ts
+++ b/apps/picsa-tools/option-tool/src/app/schemas/index.ts
@@ -6,4 +6,5 @@ export const COLLECTION = COLLECTION_V2;
 export type IOptionsToolEntry = IOptionsToolEntry_v2;
 export const SCHEMA = SCHEMA_V2;
 
+// Ensure blank templates always recreated from scratch
 export const ENTRY_TEMPLATE = ENTRY_TEMPLATE_V2;

--- a/apps/picsa-tools/option-tool/src/app/schemas/schema_v1.ts
+++ b/apps/picsa-tools/option-tool/src/app/schemas/schema_v1.ts
@@ -3,23 +3,16 @@ import { RxJsonSchema } from 'rxdb';
 
 import { IOptionsToolEntry_v0, SCHEMA_V0 } from './schema_v0';
 
-export interface IOptionsToolEntry_v1 extends IOptionsToolEntry_v0 {
-  // will be auto-populated
-  _app_user_id?: string;
-}
+export type IOptionsToolEntry_v1 = IOptionsToolEntry_v0;
+
+export const SCHEMA_V1: RxJsonSchema<IOptionsToolEntry_v1> = {
+  ...SCHEMA_V0,
+  version: 1,
+};
 
 /**
  * Converts to user collection, adding `_app_user_id` property
  */
-export const SCHEMA_V1: RxJsonSchema<IOptionsToolEntry_v1> = {
-  ...SCHEMA_V0,
-  version: 1,
-  properties: {
-    ...SCHEMA_V0.properties,
-    _app_user_id: { type: 'string' },
-  },
-};
-
 export const COLLECTION_V1: IPicsaCollectionCreator<IOptionsToolEntry_v1> = {
   schema: SCHEMA_V1,
   isUserCollection: true,
@@ -28,7 +21,6 @@ export const COLLECTION_V1: IPicsaCollectionCreator<IOptionsToolEntry_v1> = {
   migrationStrategies: {
     1: (data: IOptionsToolEntry_v0): IOptionsToolEntry_v1 => ({
       ...data,
-      _app_user_id: '__default__',
     }),
   },
 };

--- a/apps/picsa-tools/option-tool/src/app/schemas/schema_v2.ts
+++ b/apps/picsa-tools/option-tool/src/app/schemas/schema_v2.ts
@@ -1,0 +1,68 @@
+import { IPicsaCollectionCreator } from '@picsa/shared/services/core/db_v2';
+import { RxJsonSchema } from 'rxdb';
+
+import { COLLECTION_V1, IOptionsToolEntry_v1, SCHEMA_V1 } from './schema_v1';
+
+/** rename 'gender' to 'gender_activities' and add 'gender_decisions' */
+export interface IOptionsToolEntry_v2 extends Omit<IOptionsToolEntry_v1, 'gender'> {
+  gender_decisions: string[];
+  gender_activities: string[];
+}
+
+export const ENTRY_TEMPLATE_V2: IOptionsToolEntry_v2 = {
+  benefits: [],
+  gender_decisions: [],
+  gender_activities: [],
+  investment: { money: '', time: '' },
+  performance: { lowRf: '', highRf: '', midRf: '' },
+  practice: '',
+  risk: '',
+  time: '',
+  _app_user_id: '',
+};
+
+const { gender, ...v1_properties_without_gender } = SCHEMA_V1.properties;
+
+export const SCHEMA_V2: RxJsonSchema<IOptionsToolEntry_v2> = {
+  ...SCHEMA_V1,
+  version: 2,
+  properties: {
+    ...v1_properties_without_gender,
+    gender_activities: {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+    },
+    gender_decisions: {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+    },
+  },
+  // HACK - type def issue (not actually changed)
+  required: SCHEMA_V1.required as any,
+  primaryKey: SCHEMA_V1.primaryKey as any,
+};
+
+export const COLLECTION_V2: IPicsaCollectionCreator<IOptionsToolEntry_v2> = {
+  ...COLLECTION_V1,
+  schema: SCHEMA_V2,
+  // Ensure old data can be migrated to new format
+  // https://rxdb.info/data-migration.html
+  migrationStrategies: {
+    ...COLLECTION_V1.migrationStrategies,
+    2: (data: IOptionsToolEntry_v1): IOptionsToolEntry_v2 => {
+      const { gender, ...data_without_gender } = data;
+      return {
+        // rename 'gender' to 'gender_activities' and add 'gender_decisions'
+        ...data_without_gender,
+        gender_activities: gender,
+        gender_decisions: [],
+      };
+    },
+  },
+  // HACK - type def issue (not actually changed)
+  conflictHandler: COLLECTION_V1.conflictHandler as any,
+};

--- a/apps/picsa-tools/option-tool/src/app/schemas/schema_v2.ts
+++ b/apps/picsa-tools/option-tool/src/app/schemas/schema_v2.ts
@@ -1,33 +1,42 @@
+import { generateID } from '@picsa/shared/services/core/db/db.service';
 import { IPicsaCollectionCreator } from '@picsa/shared/services/core/db_v2';
 import { RxJsonSchema } from 'rxdb';
 
 import { COLLECTION_V1, IOptionsToolEntry_v1, SCHEMA_V1 } from './schema_v1';
 
-/** rename 'gender' to 'gender_activities' and add 'gender_decisions' */
+/**
+ * rename 'gender' to 'gender_activities' and add 'gender_decisions'
+ * add _id primary key
+ * */
 export interface IOptionsToolEntry_v2 extends Omit<IOptionsToolEntry_v1, 'gender'> {
   gender_decisions: string[];
   gender_activities: string[];
+  _id: string;
 }
 
-export const ENTRY_TEMPLATE_V2: IOptionsToolEntry_v2 = {
-  benefits: [],
+// Use a function to generate templates to ensure new object instantiated with id
+export const ENTRY_TEMPLATE_V2: () => IOptionsToolEntry_v2 = () => ({
+  _id: generateID(),
+  practice: '',
   gender_decisions: [],
   gender_activities: [],
-  investment: { money: '', time: '' },
+  benefits: [],
   performance: { lowRf: '', highRf: '', midRf: '' },
-  practice: '',
-  risk: '',
+  investment: { money: '', time: '' },
   time: '',
-  _app_user_id: '',
-};
+  risk: '',
+});
 
 const { gender, ...v1_properties_without_gender } = SCHEMA_V1.properties;
 
 export const SCHEMA_V2: RxJsonSchema<IOptionsToolEntry_v2> = {
   ...SCHEMA_V1,
-  version: 2,
+  version: 3,
   properties: {
     ...v1_properties_without_gender,
+    _id: {
+      type: 'string',
+    },
     gender_activities: {
       type: 'array',
       items: {
@@ -41,9 +50,8 @@ export const SCHEMA_V2: RxJsonSchema<IOptionsToolEntry_v2> = {
       },
     },
   },
-  // HACK - type def issue (not actually changed)
-  required: SCHEMA_V1.required as any,
-  primaryKey: SCHEMA_V1.primaryKey as any,
+  required: ['_id', 'practice'],
+  primaryKey: '_id',
 };
 
 export const COLLECTION_V2: IPicsaCollectionCreator<IOptionsToolEntry_v2> = {
@@ -60,6 +68,8 @@ export const COLLECTION_V2: IPicsaCollectionCreator<IOptionsToolEntry_v2> = {
         ...data_without_gender,
         gender_activities: gender,
         gender_decisions: [],
+        // add new id
+        _id: generateID(),
       };
     },
   },

--- a/apps/picsa-tools/option-tool/src/app/schemas/schema_v2.ts
+++ b/apps/picsa-tools/option-tool/src/app/schemas/schema_v2.ts
@@ -31,7 +31,7 @@ const { gender, ...v1_properties_without_gender } = SCHEMA_V1.properties;
 
 export const SCHEMA_V2: RxJsonSchema<IOptionsToolEntry_v2> = {
   ...SCHEMA_V1,
-  version: 3,
+  version: 2,
   properties: {
     ...v1_properties_without_gender,
     _id: {


### PR DESCRIPTION
## Description

**Main Changes**
- Add support for gender decisions column
- Add more icons to represent data on editor summary (particularly gender)

**Additional changes**
- Add schema migration to change legacy gender column to gender activity column
- Add unique ID to entries to simplify process of editing entries
- Tidy code to specify all option values within a single object which can be read from schema (previously multiple properties manually copied over)

## Discussion


## Preview

_Link to app preview if relevant_

## Screenshots / Videos
![localhost_4200_option(Picsa) (2)](https://github.com/e-picsa/picsa-apps/assets/10515065/d16dda7e-2f51-4cba-9dcc-e67a1c7cc69b)



