### PR TITLE
Style(extension) home page minor improvements

### DIFF
--- a/apps/picsa-apps/extension-app/src/app/material.module.ts
+++ b/apps/picsa-apps/extension-app/src/app/material.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
-import { MatGridListModule } from '@angular/material/grid-list';
 import { MatIconModule } from '@angular/material/icon';
 import { MatIconRegistry } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
@@ -10,22 +9,8 @@ import { DomSanitizer } from '@angular/platform-browser';
 
 // use custom module to make it easier to control what is available through app
 @NgModule({
-  imports: [
-    MatButtonModule,
-    MatIconModule,
-    MatCardModule,
-    MatGridListModule,
-    MatProgressBarModule,
-    MatProgressSpinnerModule,
-  ],
-  exports: [
-    MatButtonModule,
-    MatIconModule,
-    MatCardModule,
-    MatGridListModule,
-    MatProgressBarModule,
-    MatProgressSpinnerModule,
-  ],
+  imports: [MatButtonModule, MatIconModule, MatCardModule, MatProgressBarModule, MatProgressSpinnerModule],
+  exports: [MatButtonModule, MatIconModule, MatCardModule, MatProgressBarModule, MatProgressSpinnerModule],
 })
 export class ExtensionToolkitMaterialModule {
   constructor(private matIconRegistry: MatIconRegistry, private domSanitizer: DomSanitizer) {

--- a/apps/picsa-apps/extension-app/src/app/pages/home/home.page.html
+++ b/apps/picsa-apps/extension-app/src/app/pages/home/home.page.html
@@ -3,21 +3,15 @@
 </div>
 
 <div class="page-content background-image">
-  <mat-grid-list [cols]="columns" style="flex: 1" gutterSize="8">
-    <mat-grid-tile
-      *ngFor="let link of links"
-      [colspan]="link.cols"
-      [rowspan]="link.rows"
-      data-cy="link"
-      class="grid-tile"
-      (click)="linkClicked(link)"
-    >
+  <div class="link-grid">
+    <div *ngFor="let link of links" data-cy="link" class="grid-tile" (click)="linkClicked(link)">
       <div style="text-align: center">
         <mat-icon [svgIcon]="link.icon" class="nav-icon"></mat-icon>
         <div class="nav-text">{{ link.name | translate }}</div>
       </div>
-    </mat-grid-tile>
-  </mat-grid-list>
+    </div>
+  </div>
+
   <footer>
     <picsa-configuration-select></picsa-configuration-select>
     <a routerLink="privacy" class="privacy-policy">{{'Privacy Policy' | translate}}</a>

--- a/apps/picsa-apps/extension-app/src/app/pages/home/home.page.html
+++ b/apps/picsa-apps/extension-app/src/app/pages/home/home.page.html
@@ -16,9 +16,5 @@
     <picsa-configuration-select></picsa-configuration-select>
     <a routerLink="privacy" class="privacy-policy">{{'Privacy Policy' | translate}}</a>
     <div class="version-info">v{{ version.number }}</div>
-    <!-- <button mat-flat-button color="primary" (click)="shareApp()" class="share-button" [disabled]="isPreparingShare">
-      <mat-icon>share</mat-icon>
-      {{ 'Share App' | translate }}
-    </button> -->
   </footer>
 </div>

--- a/apps/picsa-apps/extension-app/src/app/pages/home/home.page.scss
+++ b/apps/picsa-apps/extension-app/src/app/pages/home/home.page.scss
@@ -1,6 +1,9 @@
 .page {
   background: var(--color-primary);
 }
+.page-content {
+  overflow: hidden;
+}
 .background-image {
   position: relative;
 }
@@ -31,13 +34,25 @@
   z-index: -1;
   opacity: 0.4;
 }
-mat-grid-tile {
+.link-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(128px, 1fr));
+  grid-auto-rows: max-content;
+  gap: 8px;
+  flex: 1;
+  margin-bottom: 3rem;
+  overflow: auto;
+  max-height: calc(100vh - 136px);
+}
+
+.grid-tile {
   background: rgba(0, 0, 0, 0.65);
   color: white;
   cursor: pointer;
   font-size: 18px;
+  padding: 16px 8px 8px 8px;
 }
-mat-grid-tile:hover {
+.grid-tile:hover {
   transform: scale(1.02);
   transition: all 0.3s ease-out;
 }
@@ -58,7 +73,11 @@ footer {
   height: 70px;
 }
 .nav-text {
-  height: 2em;
+  min-height: 3rem;
+  max-height: 4rem;
+  overflow: auto;
+  text-overflow: clip;
+  word-wrap: break-word;
 }
 .share-button {
   padding: 0;

--- a/apps/picsa-apps/extension-app/src/app/pages/home/home.page.scss
+++ b/apps/picsa-apps/extension-app/src/app/pages/home/home.page.scss
@@ -3,6 +3,7 @@
 }
 .page-content {
   overflow: hidden;
+  padding: 0;
 }
 .background-image {
   position: relative;
@@ -40,8 +41,10 @@
   grid-auto-rows: max-content;
   gap: 8px;
   flex: 1;
+  padding: 1rem;
   margin-bottom: 3rem;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   max-height: calc(100vh - 136px);
 }
 

--- a/apps/picsa-apps/extension-app/src/app/pages/home/home.page.ts
+++ b/apps/picsa-apps/extension-app/src/app/pages/home/home.page.ts
@@ -5,7 +5,13 @@ import { marker as translateMarker } from '@biesbjerg/ngx-translate-extract-mark
 import { PicsaCommonComponentsService } from '@picsa/components/src';
 import { APP_VERSION } from '@picsa/environments';
 
-const PAGE_LINKS: ILink[] = [
+interface IPageLink {
+  name: string;
+  icon: string;
+  url: string;
+}
+
+const PAGE_LINKS: IPageLink[] = [
   {
     name: translateMarker('Manual'),
     icon: 'picsa_manual_tool',
@@ -43,14 +49,12 @@ const PAGE_LINKS: ILink[] = [
   },
 
   // {
-  //   ...LINK_DEFAULTS,
   //   name: translateMarker('Discussions'),
   //   icon: 'picsa_discussions',
   //   url: '/discussions',
   // },
 
   // {
-  //   ...LINK_DEFAULTS,
   //   name: 'Settings',
   //   icon: 'picsa_settings',
   //   url: '/settings'
@@ -63,17 +67,15 @@ const PAGE_LINKS: ILink[] = [
   styleUrls: ['./home.page.scss'],
 })
 export class HomePage implements OnDestroy, AfterViewInit {
-  public links: ILink[];
+  public links = PAGE_LINKS;
   public version = APP_VERSION;
 
   @ViewChild('headerContent')
   headerContent: ElementRef<HTMLElement>;
 
-  constructor(private router: Router, private componentsService: PicsaCommonComponentsService) {
-    this.links = PAGE_LINKS;
-  }
+  constructor(private router: Router, private componentsService: PicsaCommonComponentsService) {}
 
-  linkClicked(link: ILink) {
+  linkClicked(link: IPageLink) {
     this.router.navigate([link.url]);
   }
 
@@ -85,11 +87,4 @@ export class HomePage implements OnDestroy, AfterViewInit {
       endContent: new DomPortal(this.headerContent),
     });
   }
-}
-
-interface ILink {
-  name: string;
-  icon: string;
-  img?: string;
-  url?: string;
 }

--- a/apps/picsa-apps/extension-app/src/app/pages/home/home.page.ts
+++ b/apps/picsa-apps/extension-app/src/app/pages/home/home.page.ts
@@ -1,101 +1,82 @@
 import { DomPortal } from '@angular/cdk/portal';
-import { Component, ElementRef, HostListener, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { marker as translateMarker } from '@biesbjerg/ngx-translate-extract-marker';
-import { Platform } from '@ionic/angular';
 import { PicsaCommonComponentsService } from '@picsa/components/src';
 import { APP_VERSION } from '@picsa/environments';
-import { PicsaFileService } from '@picsa/shared/services/native';
+
+const PAGE_LINKS: ILink[] = [
+  {
+    name: translateMarker('Manual'),
+    icon: 'picsa_manual_tool',
+    url: '/manual',
+  },
+  {
+    name: translateMarker('Resources'),
+    icon: 'picsa_resources_tool',
+    url: '/resources',
+  },
+  {
+    name: translateMarker('Monitoring'),
+    icon: 'picsa_data_collection',
+    url: '/monitoring',
+  },
+  {
+    name: translateMarker('Climate'),
+    icon: 'picsa_climate_tool',
+    url: '/climate',
+  },
+  {
+    name: translateMarker('Budget'),
+    icon: 'picsa_budget_tool',
+    url: '/budget',
+  },
+  {
+    name: translateMarker('Probability'),
+    icon: 'picsa_probability_tool',
+    url: '/crop-probability',
+  },
+  {
+    name: translateMarker('Options'),
+    icon: 'picsa_option_tool',
+    url: '/option',
+  },
+
+  // {
+  //   ...LINK_DEFAULTS,
+  //   name: translateMarker('Discussions'),
+  //   icon: 'picsa_discussions',
+  //   url: '/discussions',
+  // },
+
+  // {
+  //   ...LINK_DEFAULTS,
+  //   name: 'Settings',
+  //   icon: 'picsa_settings',
+  //   url: '/settings'
+  // }
+];
 
 @Component({
   selector: 'app-home',
   templateUrl: './home.page.html',
   styleUrls: ['./home.page.scss'],
 })
-export class HomePage implements OnInit, OnDestroy {
-  links: ILink[];
-  name: string;
-  version = APP_VERSION;
-  subtitle = 'Extension';
-  columns: number;
-  isPreparingShare = false;
+export class HomePage implements OnDestroy, AfterViewInit {
+  public links: ILink[];
+  public version = APP_VERSION;
 
   @ViewChild('headerContent')
   headerContent: ElementRef<HTMLElement>;
 
-  constructor(
-    private router: Router,
-    // TODO - refactor to separate store
-    private platform: Platform,
-    private fileService: PicsaFileService,
-    private componentsService: PicsaCommonComponentsService
-  ) {
-    this.links = [
-      {
-        ...LINK_DEFAULTS,
-        name: translateMarker('Manual'),
-        icon: 'picsa_manual_tool',
-        url: '/manual',
-      },
-      {
-        ...LINK_DEFAULTS,
-        name: translateMarker('Resources'),
-        icon: 'picsa_resources_tool',
-        url: '/resources',
-      },
-      {
-        ...LINK_DEFAULTS,
-        name: translateMarker('Monitoring'),
-        icon: 'picsa_data_collection',
-        url: '/monitoring',
-      },
-      {
-        ...LINK_DEFAULTS,
-        name: translateMarker('Climate'),
-        icon: 'picsa_climate_tool',
-        url: '/climate',
-      },
-      {
-        ...LINK_DEFAULTS,
-        name: translateMarker('Budget'),
-        icon: 'picsa_budget_tool',
-        url: '/budget',
-      },
-      {
-        ...LINK_DEFAULTS,
-        name: translateMarker('Probability'),
-        icon: 'picsa_probability_tool',
-        url: '/crop-probability',
-      },
-      {
-        ...LINK_DEFAULTS,
-        name: translateMarker('Options'),
-        icon: 'picsa_option_tool',
-        url: '/option',
-      },
-
-      // {
-      //   ...LINK_DEFAULTS,
-      //   name: translateMarker('Discussions'),
-      //   icon: 'picsa_discussions',
-      //   url: '/discussions',
-      // },
-
-      // {
-      //   ...LINK_DEFAULTS,
-      //   name: 'Settings',
-      //   icon: 'picsa_settings',
-      //   url: '/settings'
-      // }
-    ];
+  constructor(private router: Router, private componentsService: PicsaCommonComponentsService) {
+    this.links = PAGE_LINKS;
   }
+
   linkClicked(link: ILink) {
     this.router.navigate([link.url]);
   }
 
-  ngOnInit() {
-    this.columns = this._calculateColumns(window.innerWidth);
-  }
   ngOnDestroy(): void {
     this.componentsService.patchHeader({ endContent: undefined });
   }
@@ -104,31 +85,10 @@ export class HomePage implements OnInit, OnDestroy {
       endContent: new DomPortal(this.headerContent),
     });
   }
-  async shareApp() {
-    if (this.platform.is('cordova')) {
-      this.isPreparingShare = true;
-      await this.fileService.shareAppApk();
-      this.isPreparingShare = false;
-    }
-  }
-  @HostListener('window:resize', ['$event'])
-  onResize(event: any) {
-    this.columns = this._calculateColumns(event.target.innerWidth);
-  }
-  _calculateColumns(width: number) {
-    return width < 425 ? 2 : width < 800 ? 3 : 6;
-  }
 }
-
-const LINK_DEFAULTS = {
-  cols: 1,
-  rows: 1,
-};
 
 interface ILink {
   name: string;
-  cols: number;
-  rows: number;
   icon: string;
   img?: string;
   url?: string;


### PR DESCRIPTION
## Description
- Update home page so that footer stays visible at bottom of page
- Ensure translated text does not overflow 
- Improve grid button resizing
## Discussion

_Feedback discussion points if relevant (should also tag as `Feedback Discussion`)_

## Preview

_Link to app preview if relevant_

## Screenshots / Videos
**Before** - Footer would get pushed of page and text would get cut off
![picsa app_](https://github.com/e-picsa/picsa-apps/assets/10515065/4cc4a221-dad1-4b9a-8e94-24498ab84423)

**After** - Footer always visible and text fits
![localhost_4200_](https://github.com/e-picsa/picsa-apps/assets/10515065/f9b3d4bd-b611-4054-81ad-351353f7faa5)

