### PR TITLE
Refactor/budget tool db

### DIFF
--- a/apps/picsa-apps/extension-app-native/android/app/build.gradle
+++ b/apps/picsa-apps/extension-app-native/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "io.picsa.extension"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 3027001
-        versionName "3.27.1"
+        versionCode 3028000
+        versionName "3.28.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/apps/picsa-apps/extension-app-native/android/variables.gradle
+++ b/apps/picsa-apps/extension-app-native/android/variables.gradle
@@ -1,5 +1,5 @@
 ext {
-    minSdkVersion = 26
+    minSdkVersion = 23
     compileSdkVersion = 32
     targetSdkVersion = 32
     androidxActivityVersion = '1.4.0'

--- a/apps/picsa-tools/budget-tool/src/app/components/card/budget-card.html
+++ b/apps/picsa-tools/budget-tool/src/app/components/card/budget-card.html
@@ -8,3 +8,11 @@
   <budget-card-image [card]="card"></budget-card-image>
   <div [class]="'card-title ' + card.id">{{ card.label | translate }}</div>
 </mat-card>
+<button
+  mat-button
+  *ngIf="showCustomCardDelete && card.customMeta && !selected"
+  class="delete-button"
+  (click)="promptCustomDelete($event)"
+>
+  <mat-icon class="delete-button-icon" svgIcon="picsa_delete"></mat-icon>
+</button>

--- a/apps/picsa-tools/budget-tool/src/app/components/card/budget-card.scss
+++ b/apps/picsa-tools/budget-tool/src/app/components/card/budget-card.scss
@@ -23,3 +23,23 @@ mat-card.budget-card {
   background: #dcdcdc;
   overflow: auto;
 }
+
+.delete-button {
+  position: absolute;
+  text-align: center;
+  top: -16px;
+  right: -16px;
+  height: 36px;
+  width: 36px;
+  min-width: 36px;
+  padding: 4px;
+  font-size: 36px;
+  color: var(--color-light);
+  border: 1px solid var(--color-light);
+  border-radius: 50%;
+  background: white;
+}
+mat-icon.delete-button-icon {
+  margin-left: 0;
+  margin-right: 0;
+}

--- a/apps/picsa-tools/budget-tool/src/app/components/card/budget-card.ts
+++ b/apps/picsa-tools/budget-tool/src/app/components/card/budget-card.ts
@@ -1,7 +1,9 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { PicsaDialogService } from '@picsa/shared/features';
 
 import { IBudgetCard } from '../../schema';
 import { BudgetStore } from '../../store/budget.store';
+import { BudgetCardService } from '../../store/budget-card.service';
 
 @Component({
   selector: 'budget-card',
@@ -15,6 +17,17 @@ export class BudgetCardComponent {
   // use partial as not sure whether will be budget card or custom budget card
   @Input() card: IBudgetCard;
   @Input() selected: boolean;
+  @Input() showCustomCardDelete = true;
 
-  constructor(public store: BudgetStore) {}
+  constructor(public store: BudgetStore, private dialog: PicsaDialogService, private cardService: BudgetCardService) {}
+
+  async promptCustomDelete(e: Event) {
+    e.stopPropagation();
+    const dialogRef = await this.dialog.open('delete');
+    dialogRef.afterClosed().subscribe((v) => {
+      if (v) {
+        this.cardService.deleteCustomCard(this.card as IBudgetCard);
+      }
+    });
+  }
 }

--- a/apps/picsa-tools/budget-tool/src/app/components/card/budget-card.ts
+++ b/apps/picsa-tools/budget-tool/src/app/components/card/budget-card.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
-import { IBudgetCard } from '../../models/budget-tool.models';
+import { IBudgetCard } from '../../schema';
 import { BudgetStore } from '../../store/budget.store';
 
 @Component({

--- a/apps/picsa-tools/budget-tool/src/app/components/card/card-image/budget-card-image.ts
+++ b/apps/picsa-tools/budget-tool/src/app/components/card/card-image/budget-card-image.ts
@@ -3,7 +3,7 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy
 import { DomSanitizer, SafeHtml, SafeUrl } from '@angular/platform-browser';
 import { catchError, firstValueFrom } from 'rxjs';
 
-import { IBudgetCard } from '../../../models/budget-tool.models';
+import { IBudgetCard } from '../../../schema';
 
 @Component({
   selector: 'budget-card-image',

--- a/apps/picsa-tools/budget-tool/src/app/components/card/card-new/card-new-dialog.html
+++ b/apps/picsa-tools/budget-tool/src/app/components/card/card-new/card-new-dialog.html
@@ -1,6 +1,6 @@
 <mat-card appearance="outlined" mat-elevation-z4 class="budget-card selectable">
   <budget-card-image [card]="card"></budget-card-image>
-  <div [class]="'card-title ' + card.id">{{ card.label | translate }}</div>
+  <div class="card-title">{{ card.label | translate }}</div>
 </mat-card>
 <mat-form-field>
   <input matInput [(ngModel)]="card.label" />

--- a/apps/picsa-tools/budget-tool/src/app/components/card/card-new/card-new-dialog.ts
+++ b/apps/picsa-tools/budget-tool/src/app/components/card/card-new/card-new-dialog.ts
@@ -1,7 +1,7 @@
 import { Component, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 
-import { IBudgetCard } from '../../../models/budget-tool.models';
+import { IBudgetCard } from '../../../schema';
 
 // Dialog
 @Component({

--- a/apps/picsa-tools/budget-tool/src/app/components/card/card-new/card-new.ts
+++ b/apps/picsa-tools/budget-tool/src/app/components/card/card-new/card-new.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { marker as translateMarker } from '@biesbjerg/ngx-translate-extract-marker';
 import { generateID } from '@picsa/shared/services/core/db/db.service';
 import { toJS } from 'mobx';
 
@@ -30,7 +31,6 @@ export class BudgetCardNew {
       type: this.type,
       groupings: groupings as IBudgetCardGrouping[],
     };
-    console.log('card', card);
     const dialogRef = this.dialog.open(BudgetCardNewDialog, {
       width: '250px',
       data: card,
@@ -48,7 +48,7 @@ export class BudgetCardNew {
  ***********************************************************************/
 const PLACEHOLDER_CARD: IBudgetCard = {
   id: 'add-custom',
-  label: 'add other',
+  label: translateMarker('Add Card'),
   type: 'other',
   imgType: 'svg',
   groupings: ['*'],

--- a/apps/picsa-tools/budget-tool/src/app/components/card/card-new/card-new.ts
+++ b/apps/picsa-tools/budget-tool/src/app/components/card/card-new/card-new.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { generateDBMeta } from '@picsa/shared/services/core/db';
+import { generateID } from '@picsa/shared/services/core/db/db.service';
 import { toJS } from 'mobx';
 
 import { IBudgetCard, IBudgetCardGrouping, IBudgetCardType } from '../../../schema';
@@ -25,7 +25,8 @@ export class BudgetCardNew {
     // groupings should match the current enterprise unless otherwise specified
     const groupings = this.groupings ? this.groupings : toJS(this.store.activeBudget.meta.enterprise.groupings);
     const card: IBudgetCard = {
-      ...NEW_CARD,
+      id: generateID(),
+      label: '',
       type: this.type,
       groupings: groupings as IBudgetCardGrouping[],
     };
@@ -51,9 +52,4 @@ const PLACEHOLDER_CARD: IBudgetCard = {
   type: 'other',
   imgType: 'svg',
   groupings: ['*'],
-};
-const NEW_CARD: IBudgetCard = {
-  id: generateDBMeta()._key,
-  label: '',
-  type: 'other',
 };

--- a/apps/picsa-tools/budget-tool/src/app/components/card/card-new/card-new.ts
+++ b/apps/picsa-tools/budget-tool/src/app/components/card/card-new/card-new.ts
@@ -3,8 +3,9 @@ import { MatDialog } from '@angular/material/dialog';
 import { generateDBMeta } from '@picsa/shared/services/core/db';
 import { toJS } from 'mobx';
 
-import { IBudgetCard, IBudgetCardGrouping, IBudgetCardType } from '../../../models/budget-tool.models';
+import { IBudgetCard, IBudgetCardGrouping, IBudgetCardType } from '../../../schema';
 import { BudgetStore } from '../../../store/budget.store';
+import { BudgetCardService } from '../../../store/budget-card.service';
 import { BudgetCardNewDialog } from './card-new-dialog';
 
 @Component({
@@ -18,7 +19,7 @@ export class BudgetCardNew {
   @Output() cardSaved = new EventEmitter<IBudgetCard>();
   card = PLACEHOLDER_CARD;
 
-  constructor(public dialog: MatDialog, public store: BudgetStore) {}
+  constructor(public dialog: MatDialog, public store: BudgetStore, private cardService: BudgetCardService) {}
 
   showCardDialog() {
     // groupings should match the current enterprise unless otherwise specified
@@ -35,7 +36,7 @@ export class BudgetCardNew {
     });
 
     dialogRef.afterClosed().subscribe(async (data) => {
-      await this.store.saveCustomCard(data);
+      await this.cardService.saveCustomCard(data);
       this.cardSaved.emit(data);
     });
   }

--- a/apps/picsa-tools/budget-tool/src/app/components/cell/cell.ts
+++ b/apps/picsa-tools/budget-tool/src/app/components/cell/cell.ts
@@ -10,7 +10,7 @@ import {
 } from '@angular/core';
 import { Subscription } from 'rxjs';
 
-import { IBudgetCard } from '../../models/budget-tool.models';
+import { IBudgetCard } from '../../schema';
 import { BudgetStore } from '../../store/budget.store';
 
 @Component({

--- a/apps/picsa-tools/budget-tool/src/app/components/editor/card-editor/card-editor.component.html
+++ b/apps/picsa-tools/budget-tool/src/app/components/editor/card-editor/card-editor.component.html
@@ -1,7 +1,7 @@
 <div class="container">
   <!-- Card summary and delete button -->
   <div style="position: relative; display: flex">
-    <budget-card [card]="card"></budget-card>
+    <budget-card [card]="card" [showCustomCardDelete]="false"></budget-card>
     <button mat-stroked-button color="primary" class="delete-button" (click)="deleteClicked.emit(card)">
       <mat-icon class="delete-button-icon">close</mat-icon>
     </button>
@@ -56,13 +56,3 @@
     </mat-form-field>
   </div>
 </div>
-
-<!-- TODO - add custom card delete bindings -->
-<!-- <button
-    mat-button
-    *ngIf="card.customMeta && !selected"
-    class="delete-button"
-    (click)="promptCustomDelete($event)"
-  >
-    <mat-icon svgIcon="picsa_delete"></mat-icon>
-  </button> -->

--- a/apps/picsa-tools/budget-tool/src/app/components/editor/card-editor/card-editor.component.ts
+++ b/apps/picsa-tools/budget-tool/src/app/components/editor/card-editor/card-editor.component.ts
@@ -1,9 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { PicsaDialogService } from '@picsa/shared/features';
 
-import { IBudgetCard, IBudgetCardWithValues } from '../../../schema';
+import { IBudgetCardWithValues } from '../../../schema';
 import { BudgetStore } from '../../../store/budget.store';
-import { BudgetCardService } from '../../../store/budget-card.service';
 
 @Component({
   selector: 'budget-card-editor',
@@ -16,7 +14,7 @@ export class BudgetCardEditorComponent {
   @Output() deleteClicked = new EventEmitter<IBudgetCardWithValues>();
   @Output() valueChanged = new EventEmitter<IBudgetCardWithValues>();
 
-  constructor(private dialog: PicsaDialogService, public store: BudgetStore, private cardService: BudgetCardService) {
+  constructor(public store: BudgetStore) {
     this.currency = store.settings.currency;
   }
 
@@ -35,18 +33,5 @@ export class BudgetCardEditorComponent {
     const target = e.target as HTMLInputElement;
     this.card.values = { quantity: Number(target.value), cost: 0, total: 0 };
     this.valueChanged.emit(this.card);
-  }
-
-  async promptCustomDelete(e: Event) {
-    e.stopPropagation();
-    const dialogRef = await this.dialog.open('delete');
-    dialogRef.afterClosed().subscribe((v) => {
-      if (v) {
-        this.cardService.deleteCustomCard(this.card as IBudgetCard);
-        // HACK - instead of refreshing from store just mark
-        // as deleted to hide (will be gone next refresh)
-        this.card['_deleted'] = true;
-      }
-    });
   }
 }

--- a/apps/picsa-tools/budget-tool/src/app/components/editor/card-editor/card-editor.component.ts
+++ b/apps/picsa-tools/budget-tool/src/app/components/editor/card-editor/card-editor.component.ts
@@ -1,8 +1,9 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { PicsaDialogService } from '@picsa/shared/features';
 
-import { IBudgetCardDB, IBudgetCardWithValues } from '../../../models/budget-tool.models';
+import { IBudgetCard, IBudgetCardWithValues } from '../../../schema';
 import { BudgetStore } from '../../../store/budget.store';
+import { BudgetCardService } from '../../../store/budget-card.service';
 
 @Component({
   selector: 'budget-card-editor',
@@ -15,7 +16,7 @@ export class BudgetCardEditorComponent {
   @Output() deleteClicked = new EventEmitter<IBudgetCardWithValues>();
   @Output() valueChanged = new EventEmitter<IBudgetCardWithValues>();
 
-  constructor(private dialog: PicsaDialogService, public store: BudgetStore) {
+  constructor(private dialog: PicsaDialogService, public store: BudgetStore, private cardService: BudgetCardService) {
     this.currency = store.settings.currency;
   }
 
@@ -41,7 +42,7 @@ export class BudgetCardEditorComponent {
     const dialogRef = await this.dialog.open('delete');
     dialogRef.afterClosed().subscribe((v) => {
       if (v) {
-        this.store.deleteCustomCard(this.card as IBudgetCardDB);
+        this.cardService.deleteCustomCard(this.card as IBudgetCard);
         // HACK - instead of refreshing from store just mark
         // as deleted to hide (will be gone next refresh)
         this.card['_deleted'] = true;

--- a/apps/picsa-tools/budget-tool/src/app/components/editor/card-select/card-select.ts
+++ b/apps/picsa-tools/budget-tool/src/app/components/editor/card-select/card-select.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ANIMATION_DELAYED, FadeInOut } from '@picsa/shared/animations';
 
-import { IBudgetCard, IBudgetCardType, IBudgetCardWithValues } from '../../../models/budget-tool.models';
+import { IBudgetCard, IBudgetCardType, IBudgetCardWithValues } from '../../../schema';
 import { BudgetStore } from '../../../store/budget.store';
 
 @Component({

--- a/apps/picsa-tools/budget-tool/src/app/components/editor/card-select/family-labour/family-labour.ts
+++ b/apps/picsa-tools/budget-tool/src/app/components/editor/card-select/family-labour/family-labour.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, Output, QueryList, ViewChildren } from 
 import { MatInput } from '@angular/material/input';
 import { marker as translateMarker } from '@biesbjerg/ngx-translate-extract-marker';
 
-import { IBudgetCardWithValues } from '../../../../models/budget-tool.models';
+import { IBudgetCardWithValues } from '../../../../schema';
 
 const LABELS: { [id: string]: string } = {
   adultMale: translateMarker('Male Member'),

--- a/apps/picsa-tools/budget-tool/src/app/components/editor/card-select/produce-consumed/produce-consumed.ts
+++ b/apps/picsa-tools/budget-tool/src/app/components/editor/card-select/produce-consumed/produce-consumed.ts
@@ -1,8 +1,8 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { BudgetCardService } from '@picsa/budget/src/app/store/budget-card.service';
 
 import { IBudgetCardWithValues } from '../../../../schema';
 import { BudgetStore } from '../../../../store/budget.store';
+import { BudgetCardService } from '../../../../store/budget-card.service';
 
 @Component({
   selector: 'budget-cell-editor-produce-consumed',

--- a/apps/picsa-tools/budget-tool/src/app/components/editor/editor.component.html
+++ b/apps/picsa-tools/budget-tool/src/app/components/editor/editor.component.html
@@ -27,8 +27,8 @@
 
 <!-- Dialog -->
 <ng-template #cardsListDialog>
-  <div id="cardsList" *ngIf="data && cardsListType && store.budgetCardsByType">
-    <div #cardScroller style="flex: 1; overflow: auto" [ngSwitch]="cardsListType">
+  <div id="cardsList" *ngIf="data && periodType">
+    <div #cardScroller style="flex: 1; overflow: auto" [ngSwitch]="periodType">
       <!-- Family Labour -->
       <budget-cell-editor-family-labour
         *ngSwitchCase="'familyLabour'"
@@ -45,10 +45,10 @@
       <!-- Default Editor -->
       <budget-cell-editor-card-select
         *ngSwitchDefault
-        [type]="cardsListType"
-        [values]="data[cardsListType]"
-        [cards]="store.budgetCardsByType[cardsListType]"
-        (valueChanged)="onEditorChange($event, cardsListType)"
+        [type]="periodType"
+        [values]="data[periodType]"
+        [cards]="budgetCards"
+        (valueChanged)="onEditorChange($event, periodType)"
       >
       </budget-cell-editor-card-select>
     </div>

--- a/apps/picsa-tools/budget-tool/src/app/data/cards.ts
+++ b/apps/picsa-tools/budget-tool/src/app/data/cards.ts
@@ -1,4 +1,4 @@
-import type { IBudgetCard } from '../models/budget-tool.models';
+import type { IBudgetCard } from '../schema/cards';
 
 // This data is automatically populated on first load and update from live when available
 export const BUDGET_CARDS: IBudgetCard[] = [

--- a/apps/picsa-tools/budget-tool/src/app/models/budget-tool.models.ts
+++ b/apps/picsa-tools/budget-tool/src/app/models/budget-tool.models.ts
@@ -1,5 +1,6 @@
-import { marker as translateMarker } from '@biesbjerg/ngx-translate-extract-marker';
 import { IDBDoc } from '@picsa/models';
+
+import { IBudgetCard, IBudgetCardWithValues } from '../schema';
 
 export interface IBudget extends IDBDoc {
   data: IBudgetPeriodData[];
@@ -47,52 +48,6 @@ export interface IBudgetQueryParams {
 // active cell data is calculated separately by store
 export interface IBudgetActiveCell extends IBudgetQueryParams {
   data: IBudgetCardWithValues[];
-}
-
-/***************************************************************************** */
-
-/** Specify available groupings to ensure translations included */
-const BUDGET_CARD_GROUPINGS = {
-  livestock: translateMarker('livestock'),
-  fruits: translateMarker('fruits'),
-  crop: translateMarker('crop'),
-  fish: translateMarker('fish'),
-  afforestation: translateMarker('afforestation'),
-  '*': '*',
-} as const;
-
-export type IBudgetCardGrouping = keyof typeof BUDGET_CARD_GROUPINGS;
-
-// cards are used for budget table population as well as enterprise
-export interface IBudgetCard {
-  // id used as well as key to easier specify image (and be non-unique for things like inputs and outputs)
-  id: string;
-  label: string;
-  type: IBudgetCardType;
-  groupings?: IBudgetCardGrouping[];
-  customMeta?: IBudgetCardCustomMeta;
-  values?: IBudgetCardValues;
-  imgType?: 'svg' | 'png';
-  /** Optional image overide (default used card id) */
-  imgId?: string;
-  _deleted?: boolean;
-}
-export type IBudgetCardDB = IBudgetCard & IDBDoc;
-export type IBudgetCardType = IBudgetPeriodType | 'enterprise' | 'other';
-
-export interface IBudgetCardWithValues extends IBudgetCard {
-  values: IBudgetCardValues;
-}
-
-interface IBudgetCardCustomMeta {
-  imgData: string;
-  dateCreated: string;
-  createdBy: string;
-}
-export interface IBudgetCardValues {
-  quantity: number;
-  cost: number;
-  total: number;
 }
 
 /***************************************************************************** */

--- a/apps/picsa-tools/budget-tool/src/app/pages/create/budget-create.page.html
+++ b/apps/picsa-tools/budget-tool/src/app/pages/create/budget-create.page.html
@@ -10,7 +10,7 @@
             *ngFor="let card of enterpriseTypeCards; trackBy: trackByFn"
             [card]="card"
             (click)="enterpriseTypeClicked(card.id)"
-            [selected]="selectedType === card.id"
+            [selected]="enterpriseType === card.id"
             @fadeInOut
           ></budget-card>
         </div>
@@ -35,14 +35,14 @@
           <budget-card
             *ngFor="let enterprise of filteredEnterprises"
             [card]="enterprise"
-            (click)="enterpriseClicked(enterprise)"
+            (click)="setEnterprise(enterprise)"
             [selected]="budgetMetaForm.value.enterprise.id === enterprise.id"
             @fadeInOut
           >
           </budget-card>
           <budget-card-new
             type="enterprise"
-            [groupings]="[selectedType]"
+            [groupings]="[enterpriseType]"
             (cardSaved)="customEnterpriseCreated($event)"
           ></budget-card-new>
         </div>

--- a/apps/picsa-tools/budget-tool/src/app/schema/cards/common.ts
+++ b/apps/picsa-tools/budget-tool/src/app/schema/cards/common.ts
@@ -1,0 +1,31 @@
+import { marker as translateMarker } from '@biesbjerg/ngx-translate-extract-marker';
+
+import type { IBudgetPeriodType } from '../../models/budget-tool.models';
+import { IBudgetCard } from '.';
+
+/** Specify available groupings to ensure translations included */
+const BUDGET_CARD_GROUPINGS = {
+  livestock: translateMarker('livestock'),
+  fruits: translateMarker('fruits'),
+  crop: translateMarker('crop'),
+  fish: translateMarker('fish'),
+  afforestation: translateMarker('afforestation'),
+  '*': '*',
+} as const;
+
+export type IBudgetCardGrouping = keyof typeof BUDGET_CARD_GROUPINGS;
+
+export type IBudgetCardType = IBudgetPeriodType | 'enterprise' | 'other';
+export interface IBudgetCardWithValues extends IBudgetCard {
+  values: IBudgetCardValues;
+}
+export interface IBudgetCardCustomMeta {
+  imgData: string;
+  dateCreated: string;
+  createdBy: string;
+}
+export interface IBudgetCardValues {
+  quantity: number;
+  cost: number;
+  total: number;
+}

--- a/apps/picsa-tools/budget-tool/src/app/schema/cards/index.ts
+++ b/apps/picsa-tools/budget-tool/src/app/schema/cards/index.ts
@@ -1,0 +1,9 @@
+import { COLLECTION_V1, ENTRY_TEMPLATE_V1, IBudgetCard_v1, SCHEMA_V1 } from './schema_v1';
+export * from './common';
+
+// Re-export schema to provide latest version without need to refactor additonal code
+
+export const COLLECTION = COLLECTION_V1;
+export type IBudgetCard = IBudgetCard_v1;
+export const SCHEMA = SCHEMA_V1;
+export const ENTRY_TEMPLATE = ENTRY_TEMPLATE_V1;

--- a/apps/picsa-tools/budget-tool/src/app/schema/cards/schema_v1.ts
+++ b/apps/picsa-tools/budget-tool/src/app/schema/cards/schema_v1.ts
@@ -1,0 +1,69 @@
+import { generateID } from '@picsa/shared/services/core/db/db.service';
+import { IPicsaCollectionCreator } from '@picsa/shared/services/core/db_v2';
+import { RxJsonSchema } from 'rxdb';
+
+import { IBudgetCardCustomMeta, IBudgetCardGrouping, IBudgetCardType, IBudgetCardValues } from './common';
+
+// Initial migration simply the same as legacy version
+// cards are used for budget table population as well as enterprise
+
+export type IBudgetCard_v1 = {
+  // id used as well as key to easier specify image (and be non-unique for things like inputs and outputs)
+  id: string;
+  label: string;
+  type: IBudgetCardType;
+  groupings?: IBudgetCardGrouping[];
+  customMeta?: IBudgetCardCustomMeta;
+  values?: IBudgetCardValues;
+  imgType?: 'svg' | 'png';
+  /** Optional image overide (default used card id) */
+  imgId?: string;
+  _deleted?: boolean;
+};
+
+export const SCHEMA_V1: RxJsonSchema<IBudgetCard_v1> = {
+  version: 1,
+  keyCompression: false,
+  type: 'object',
+  required: ['id'],
+  primaryKey: 'id',
+  indexes: ['type'],
+  properties: {
+    _deleted: { type: 'boolean' },
+    customMeta: { type: 'object' },
+    id: { type: 'string' },
+    groupings: { type: 'array' },
+    imgId: { type: 'string' },
+    imgType: { type: 'string' },
+    label: { type: 'string' },
+    type: { type: 'string' },
+    values: { type: 'object' },
+  },
+};
+
+export const COLLECTION_V1: IPicsaCollectionCreator<IBudgetCard_v1> = {
+  schema: SCHEMA_V1,
+  isUserCollection: true,
+  migrationStrategies: {
+    1: async (data) => {
+      console.log('migrate old data', data);
+    },
+  },
+};
+
+/** Entry template used for user-generated budget cards */
+export const ENTRY_TEMPLATE_V1 = (options: {
+  type: IBudgetCardType;
+  groupings: IBudgetCard_v1['groupings'];
+  label: string;
+  imgData: string;
+}): IBudgetCard_v1 => {
+  const { groupings, label, type, imgData } = options;
+  return {
+    id: generateID(),
+    customMeta: { imgData, createdBy: '', dateCreated: new Date().toISOString() },
+    groupings,
+    label,
+    type,
+  };
+};

--- a/apps/picsa-tools/budget-tool/src/app/schema/index.ts
+++ b/apps/picsa-tools/budget-tool/src/app/schema/index.ts
@@ -1,0 +1,1 @@
+export * from './cards';

--- a/apps/picsa-tools/budget-tool/src/app/store/budget-card.service.ts
+++ b/apps/picsa-tools/budget-tool/src/app/store/budget-card.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@angular/core';
+import { PicsaAsyncService } from '@picsa/shared/services/asyncService.service';
+import { PicsaDatabase_V2_Service } from '@picsa/shared/services/core/db_v2';
+import { RxCollection } from 'rxdb';
+
+import { BUDGET_CARDS } from '../data';
+import * as CardSchema from '../schema/cards';
+
+const COLLECTION_NAME = 'budget_cards';
+
+@Injectable({ providedIn: 'root' })
+export class BudgetCardService extends PicsaAsyncService {
+  constructor(private dbService: PicsaDatabase_V2_Service) {
+    super();
+    this.ready().then(() => console.log('[Budget Card] service ready'));
+  }
+
+  public override async init() {
+    await this.dbService.ready();
+    await this.dbService.ensureCollections({
+      [COLLECTION_NAME]: CardSchema.COLLECTION,
+    });
+    await this.loadHardcodedData();
+  }
+
+  public get dbCollection() {
+    return this.dbService.db.collections[COLLECTION_NAME] as RxCollection<CardSchema.IBudgetCard>;
+  }
+
+  public async getEnterpriseGroupCards() {
+    await this.ready();
+    const docs = await this.dbCollection.find({ selector: { type: 'enterprise' } }).exec();
+    const cards = docs.map((d) => d._data);
+    const groups = this.groupEnterpriseCards(cards);
+    console.log({ groups });
+    return groups;
+  }
+
+  public async saveCustomCard(card: CardSchema.IBudgetCard) {
+    // await this.db.setDoc('budgetTool/_all/cards', card);
+    // // re-populate budget cards
+    // console.log('card saved', card);
+  }
+  public async deleteCustomCard(card: CardSchema.IBudgetCard) {
+    // return this.db.deleteDocs('budgetTool/_all/cards', [card._key]);
+  }
+
+  private async loadHardcodedData() {
+    return this.dbCollection.bulkUpsert(BUDGET_CARDS);
+  }
+
+  /**
+   * group all enterprise cards and create new parent card that will be used to reveal group
+   * @param cards
+   * @returns
+   */
+  private groupEnterpriseCards(cards: CardSchema.IBudgetCard[]): CardSchema.IBudgetCard[] {
+    const allGroupings: string[][] = cards.map((e) => e.groupings as string[]);
+    // eslint-disable-next-line prefer-spread
+    const mergedGroupings: string[] = ([] as any).concat.apply([], allGroupings);
+    // NOTE - technically Array.from shouldn't be required but current issue with typescript
+    // see https://stackoverflow.com/questions/33464504/using-spread-syntax-and-new-set-with-typescript/33464709
+    const uniqueGroups = [...Array.from(new Set(mergedGroupings))].sort();
+    const enterpriseTypeCards: CardSchema.IBudgetCard[] = uniqueGroups.map((group) => {
+      return {
+        id: group,
+        label: group,
+        type: 'enterprise',
+        imgType: 'svg',
+        _key: `_group_${group}`,
+        _created: new Date().toISOString(),
+        _modified: new Date().toISOString(),
+      };
+    });
+    return enterpriseTypeCards;
+  }
+}

--- a/apps/picsa-tools/budget-tool/src/app/store/budget-card.service.ts
+++ b/apps/picsa-tools/budget-tool/src/app/store/budget-card.service.ts
@@ -13,6 +13,7 @@ export class BudgetCardService extends PicsaAsyncService {
   constructor(private dbService: PicsaDatabase_V2_Service) {
     super();
     this.ready().then(() => console.log('[Budget Card] service ready'));
+    // TODO - migrate legacy db custom cards (if possible)
   }
 
   public override async init() {
@@ -32,17 +33,15 @@ export class BudgetCardService extends PicsaAsyncService {
     const docs = await this.dbCollection.find({ selector: { type: 'enterprise' } }).exec();
     const cards = docs.map((d) => d._data);
     const groups = this.groupEnterpriseCards(cards);
-    console.log({ groups });
     return groups;
   }
 
   public async saveCustomCard(card: CardSchema.IBudgetCard) {
-    // await this.db.setDoc('budgetTool/_all/cards', card);
-    // // re-populate budget cards
-    // console.log('card saved', card);
+    return this.dbCollection.upsert(card);
   }
   public async deleteCustomCard(card: CardSchema.IBudgetCard) {
-    // return this.db.deleteDocs('budgetTool/_all/cards', [card._key]);
+    const ref = this.dbCollection.findOne(card.id);
+    return ref.remove();
   }
 
   private async loadHardcodedData() {

--- a/apps/picsa-tools/climate-tool/src/app/components/chart-tools/line-tool/line-tool.component.scss
+++ b/apps/picsa-tools/climate-tool/src/app/components/chart-tools/line-tool/line-tool.component.scss
@@ -13,11 +13,10 @@
   text-align: center;
   height: 64px;
 }
-.lineToolInput {
-  width: 60px;
+input.lineToolInput {
   margin-left: -16px;
   margin-right: -16px;
-  text-align: center;
+  font-size: 24px;
 }
 .calendar-picker-button {
   margin-left: -10px;

--- a/apps/picsa-tools/climate-tool/src/app/services/climate-chart.service.ts
+++ b/apps/picsa-tools/climate-tool/src/app/services/climate-chart.service.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Injectable } from '@angular/core';
-import type { IChartConfig, IChartId, IChartMeta, IStationData, IStationMeta, IStationMetaDB } from '@picsa/models';
+import type { IChartConfig, IChartId, IChartMeta, IStationData, IStationMetaDB } from '@picsa/models';
 import { PicsaChartComponent } from '@picsa/shared/features/charts/chart';
 import { PicsaTranslateService } from '@picsa/shared/modules';
 import { PrintProvider } from '@picsa/shared/services/native';

--- a/apps/picsa-tools/climate-tool/src/app/services/climate-data.service.ts
+++ b/apps/picsa-tools/climate-tool/src/app/services/climate-data.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@angular/core';
 import { IChartMeta, IStationData, IStationMetaDB } from '@picsa/models';
+import { arrayToHashmap } from '@picsa/utils';
 import * as Papa from 'papaparse';
 
 import * as DATA from '../data';
-import { arrayToHashmap } from '@picsa/utils';
 
 @Injectable({ providedIn: 'root' })
 export class ClimateDataService {

--- a/libs/shared/src/modules/database_v2/db.module.ts
+++ b/libs/shared/src/modules/database_v2/db.module.ts
@@ -7,7 +7,7 @@ import { PicsaDatabase_V2_Service } from '../../services/core/db_v2/db.service';
  * https://stackoverflow.com/questions/46257184/angular-async-factory-provider
  */
 function dbInitFactory(dbService: PicsaDatabase_V2_Service) {
-  return () => dbService.initialise();
+  return () => dbService.ready();
 }
 
 /**

--- a/libs/utils/data.ts
+++ b/libs/utils/data.ts
@@ -32,3 +32,21 @@ export function hashmapToArray<T>(hashmap: Record<string, T>, keyfield: keyof T)
     return value;
   });
 }
+
+/** Convert an array into an object grouped by specific key */
+export function arrayToHashmapArray<T extends object>(arr: T[], keyfield: keyof T) {
+  const hashmap: Record<string, T[]> = {} as any;
+  if (!Array.isArray(arr)) {
+    console.error('Cannot convert non-array to hashmap', { arr, keyfield });
+    return {};
+  }
+
+  for (const el of arr) {
+    const hashKey = el[keyfield] as string;
+    if (!(hashKey in hashmap)) {
+      hashmap[hashKey] = [];
+    }
+    hashmap[hashKey].push(el);
+  }
+  return hashmap;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picsa-apps",
-  "version": "3.27.1",
+  "version": "3.28.0",
   "license": "See LICENSE",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Description
- Refactor code to make it easier to work with budget cards
- Migrate budget card data to populate via the improved db system
- Fix bug where creating new budget cards would not show immediately
- Fix bug where creating new budget cards would show duplicates
- Add feature to delete custom created cards

**Additional changes**
- Drop minimum target API to support Android 6.0
- Fix climate line tool to allow 4 digits of text input (e.g. rainfall 1200mm)


## Discussion

_Feedback discussion points if relevant (should also tag as `Feedback Discussion`)_

## Preview

_Link to app preview if relevant_

## Screenshots / Videos

_Include at least 1-2 screenshots of videos if visual changes_
