### PR TITLE
feat(core): data table custom value templates and header formatter

### DIFF
--- a/libs/shared/src/features/data-table/data-table.component.html
+++ b/libs/shared/src/features/data-table/data-table.component.html
@@ -19,10 +19,23 @@
 <table mat-table matSort [dataSource]="dataSource" [matSortDisabled]="!tableOptions.sort">
   @for(column of tableOptions.displayColumns; track column){
   <ng-container [matColumnDef]="column">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ column }}</th>
-    <td mat-cell *matCellDef="let el">{{ el[column] }}</td>
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ column | formatValue: tableOptions.formatHeader }}</th>
+
+    <td mat-cell *matCellDef="let el">
+      @if(valueTemplates[column]){
+      <!-- custom value templates  -->
+      <ng-container
+        [ngTemplateOutlet]="valueTemplates[column]"
+        [ngTemplateOutletContext]="{ $implicit: el[column] }"
+      ></ng-container>
+      } @else {
+      <!-- Default value template -->
+      {{ el[column] }}
+      }
+    </td>
   </ng-container>
   }
+
   <tr mat-header-row *matHeaderRowDef="tableOptions.displayColumns"></tr>
   <tr
     mat-row

--- a/libs/utils/data.ts
+++ b/libs/utils/data.ts
@@ -84,3 +84,9 @@ export function jsonNestedProperty<T>(obj: any, nestedPath: string) {
 export function base64ToBlob(base64String, mimetype: string) {
   return createBlobFromBase64(base64String, mimetype);
 }
+
+/** Capitalise the first letter of a string */
+export function capitalise(str: string) {
+  if (typeof str !== 'string') return str;
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}


### PR DESCRIPTION
## Description

- Add support for providing custom display templates when using shared picsa-data-table

## Discussion

_Feedback discussion points if relevant (should also tag as `Feedback Discussion`)_

## Preview

_Link to app preview if relevant_

## Screenshots / Videos

_Include at least 1-2 screenshots of videos if visual changes_
