### PR TITLE
Feat(dashboard): add home page

### DIFF
--- a/apps/picsa-apps/dashboard/src/app/app.component.html
+++ b/apps/picsa-apps/dashboard/src/app/app.component.html
@@ -37,7 +37,12 @@
             [routerLinkActiveOptions]="{ exact: false }"
           >
             <mat-panel-title>
-              {{ link.label }}
+              <div class="nav-item">
+                @if(link.matIcon){
+                <mat-icon style="margin-right: 8px">{{ link.matIcon }}</mat-icon>
+                }
+                <span>{{ link.label }}</span>
+              </div>
             </mat-panel-title>
           </mat-expansion-panel-header>
           @for(child of link.children || []; track $index){
@@ -53,7 +58,12 @@
         } @else {
         <!-- Single nav item -->
         <a mat-list-item [routerLink]="link.href" routerLinkActive="mdc-list-item--activated active-link">
-          {{ link.label }}
+          <div class="nav-item">
+            @if(link.matIcon){
+            <mat-icon style="margin-right: 8px">{{ link.matIcon }}</mat-icon>
+            }
+            <span>{{ link.label }}</span>
+          </div>
         </a>
         } }
         <mat-divider style="margin-top: auto"></mat-divider>

--- a/apps/picsa-apps/dashboard/src/app/app.component.scss
+++ b/apps/picsa-apps/dashboard/src/app/app.component.scss
@@ -3,7 +3,6 @@ mat-sidenav {
 }
 mat-nav-list {
   --mdc-list-list-item-one-line-container-height: 48px;
-
   height: calc(100% - 16px);
   display: flex;
   flex-direction: column;
@@ -14,6 +13,10 @@ mat-toolbar {
 mat-sidenav-content {
   display: flex;
   flex-direction: column;
+}
+.nav-item {
+  display: flex;
+  align-items: center;
 }
 .active-link {
   text-decoration: underline;

--- a/apps/picsa-apps/dashboard/src/app/app.component.ts
+++ b/apps/picsa-apps/dashboard/src/app/app.component.ts
@@ -3,13 +3,8 @@ import { AfterViewInit, Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { SupabaseService } from '@picsa/shared/services/core/supabase';
 
+import { DASHBOARD_NAV_LINKS, INavLink } from './data';
 import { DashboardMaterialModule } from './material.module';
-
-interface INavLink {
-  label: string;
-  href: string;
-  children?: INavLink[];
-}
 
 @Component({
   standalone: true,
@@ -21,38 +16,7 @@ interface INavLink {
 export class AppComponent implements AfterViewInit {
   title = 'picsa-apps-dashboard';
 
-  navLinks: INavLink[] = [
-    {
-      label: 'Resources',
-      href: '/resources',
-    },
-    {
-      label: 'Climate',
-      href: '/climate',
-      children: [
-        {
-          label: 'Station Data',
-          href: '/station',
-        },
-        {
-          label: 'Forecasts',
-          href: '/forecast',
-        },
-      ],
-    },
-    // {
-    //   label: 'Crop Information',
-    //   href: '/crop-information',
-    // },
-    // {
-    //   label: 'Monitoring Forms',
-    //   href: '/monitoring-forms',
-    // },
-    {
-      label: 'Translations',
-      href: '/translations',
-    },
-  ];
+  navLinks = DASHBOARD_NAV_LINKS;
 
   globalLinks: INavLink[] = [
     // {

--- a/apps/picsa-apps/dashboard/src/app/app.routes.ts
+++ b/apps/picsa-apps/dashboard/src/app/app.routes.ts
@@ -1,6 +1,12 @@
 import { Route } from '@angular/router';
 
+import { DashboardHomeComponent } from './modules/home/home.component';
+
 export const appRoutes: Route[] = [
+  {
+    path: 'home',
+    component: DashboardHomeComponent,
+  },
   {
     path: 'resources',
     loadChildren: () => import('./modules/resources/resources.module').then((m) => m.ResourcesPageModule),
@@ -13,9 +19,10 @@ export const appRoutes: Route[] = [
     path: 'translations',
     loadChildren: () => import('./modules/translations/translations.module').then((m) => m.TranslationsPageModule),
   },
+  // unmatched routes fallback to home
   {
-    path: '',
-    redirectTo: 'resources',
+    path: '**',
+    redirectTo: 'home',
     pathMatch: 'full',
   },
 ];

--- a/apps/picsa-apps/dashboard/src/app/data/index.ts
+++ b/apps/picsa-apps/dashboard/src/app/data/index.ts
@@ -1,0 +1,1 @@
+export * from './navLinks';

--- a/apps/picsa-apps/dashboard/src/app/data/navLinks.ts
+++ b/apps/picsa-apps/dashboard/src/app/data/navLinks.ts
@@ -1,0 +1,47 @@
+export interface INavLink {
+  label: string;
+  href: string;
+  matIcon?: string;
+  children?: INavLink[];
+}
+
+export const DASHBOARD_NAV_LINKS = [
+  {
+    label: 'Home',
+    href: '/home',
+    matIcon: 'home',
+  },
+  {
+    label: 'Resources',
+    href: '/resources',
+    matIcon: 'library_books',
+  },
+  {
+    label: 'Climate',
+    href: '/climate',
+    matIcon: 'filter_drama',
+    children: [
+      {
+        label: 'Station Data',
+        href: '/station',
+      },
+      {
+        label: 'Forecasts',
+        href: '/forecast',
+      },
+    ],
+  },
+  // {
+  //   label: 'Crop Information',
+  //   href: '/crop-information',
+  // },
+  // {
+  //   label: 'Monitoring Forms',
+  //   href: '/monitoring-forms',
+  // },
+  {
+    label: 'Translations',
+    href: '/translations',
+    matIcon: 'translate',
+  },
+];

--- a/apps/picsa-apps/dashboard/src/app/modules/home/home.component.html
+++ b/apps/picsa-apps/dashboard/src/app/modules/home/home.component.html
@@ -1,0 +1,18 @@
+<div class="page-content">
+  <h2>PICSA Dashboard</h2>
+  <p>Use the links below to administer the PICSA App:</p>
+  <div class="link-container">
+    @for (link of links; track $index) {
+    <mat-card [routerLink]="link.href">
+      <mat-card-header class="link-label">
+        <div>{{ link.label }}</div>
+      </mat-card-header>
+      <mat-card-content>
+        @if(link.matIcon){
+        <mat-icon class="link-icon">{{ link.matIcon }}</mat-icon>
+        }
+      </mat-card-content>
+    </mat-card>
+    }
+  </div>
+</div>

--- a/apps/picsa-apps/dashboard/src/app/modules/home/home.component.scss
+++ b/apps/picsa-apps/dashboard/src/app/modules/home/home.component.scss
@@ -1,0 +1,34 @@
+.link-container {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(3, 1fr);
+  max-width: 764px;
+}
+
+mat-card:hover {
+  cursor: pointer;
+  font-weight: bold;
+
+  mat-card-header.link-label {
+    background: var(--color-primary-50);
+  }
+  mat-icon.link-icon {
+    transform: scale(1.05);
+  }
+}
+mat-card-header.link-label {
+  padding: 0.5rem;
+  justify-content: center;
+  background: whitesmoke;
+}
+mat-icon.link-icon {
+  display: block;
+  font-size: 48px;
+  height: 48px;
+  width: 48px;
+  margin: auto;
+  transition: all 0.3s ease-out;
+}
+mat-card-content {
+  padding: 1rem;
+}

--- a/apps/picsa-apps/dashboard/src/app/modules/home/home.component.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/home/home.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { RouterModule } from '@angular/router';
+
+import { DASHBOARD_NAV_LINKS } from '../../data';
+
+@Component({
+  selector: 'dashboard-home',
+  templateUrl: 'home.component.html',
+  styleUrl: 'home.component.scss',
+  standalone: true,
+  imports: [MatCardModule, MatIconModule, RouterModule],
+})
+export class DashboardHomeComponent {
+  public links = DASHBOARD_NAV_LINKS.filter((l) => l.href !== '/home');
+}


### PR DESCRIPTION
## Description

Add minimal dashboard home page to help direct users towards different dashboard sections.
Also updates nav bar to include icons for different dashboard sections

## Screenshots / Videos
![localhost_4200_home(720p)](https://github.com/e-picsa/picsa-apps/assets/10515065/744bb2be-39f9-4a76-ae01-984337bf4a21)
