### PR TITLE
Feat(dashboard): deployments system UI and DB

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -11,7 +11,7 @@
   { 'color': 'e4e669', 'description': "This doesn't seem right", 'name': 'invalid' },
   { 'color': 'd876e3', 'description': 'Further information is requested', 'name': 'question' },
   { 'color': 'ffffff', 'description': 'This will not be worked on', 'name': 'wontfix' },
-  { 'color': 'ffffff', 'description': 'Disable PR autolabel actions', 'name': 'no-autolable' },
+  { 'color': 'ffffff', 'description': 'Disable PR autolabel actions', 'name': 'no-autolabel' },
   { 'color': '0366d6', 'description': 'Pull requests that update a dependency file', 'name': 'dependencies' },
   { 'color': 'CF3458', 'description': '', 'name': 'Feedback Discussion' },
   { 'color': 'ffffff', 'description': '', 'name': 'Test - Preview' },

--- a/apps/picsa-apps/dashboard/src/app/app.component.html
+++ b/apps/picsa-apps/dashboard/src/app/app.component.html
@@ -3,7 +3,8 @@
     <button mat-icon-button (click)="sidenav.opened = !sidenav.opened">
       <mat-icon>menu</mat-icon>
     </button>
-    <span style="flex: 1">PICSA Dashboard</span>
+    <dashboard-deployment-select />
+    <span style="flex: 1; text-align: center;">PICSA Dashboard</span>
     @if(supabaseService.auth.authUser(); as user){
     <div style="position: relative">
       <button mat-button (click)="supabaseService.auth.signOut()" style="margin-top: 16px">

--- a/apps/picsa-apps/dashboard/src/app/app.component.html
+++ b/apps/picsa-apps/dashboard/src/app/app.component.html
@@ -37,12 +37,7 @@
             [routerLinkActiveOptions]="{ exact: false }"
           >
             <mat-panel-title>
-              <div class="nav-item">
-                @if(link.matIcon){
-                <mat-icon style="margin-right: 8px">{{ link.matIcon }}</mat-icon>
-                }
-                <span>{{ link.label }}</span>
-              </div>
+              <ng-container *ngTemplateOutlet="linkTemplate; context: { $implicit: link }"></ng-container>
             </mat-panel-title>
           </mat-expansion-panel-header>
           @for(child of link.children || []; track $index){
@@ -58,12 +53,7 @@
         } @else {
         <!-- Single nav item -->
         <a mat-list-item [routerLink]="link.href" routerLinkActive="mdc-list-item--activated active-link">
-          <div class="nav-item">
-            @if(link.matIcon){
-            <mat-icon style="margin-right: 8px">{{ link.matIcon }}</mat-icon>
-            }
-            <span>{{ link.label }}</span>
-          </div>
+          <ng-container *ngTemplateOutlet="linkTemplate; context: { $implicit: link }"></ng-container>
         </a>
         } }
         <mat-divider style="margin-top: auto"></mat-divider>
@@ -71,7 +61,7 @@
         <mat-divider></mat-divider>
         @for (link of globalLinks; track link.href) {
         <a mat-list-item [routerLink]="link.href" routerLinkActive="mdc-list-item--activated active-link">
-          {{ link.label }}
+          <ng-container *ngTemplateOutlet="linkTemplate; context: { $implicit: link }"></ng-container>
         </a>
         }
       </mat-nav-list>
@@ -81,3 +71,12 @@
     </mat-sidenav-content>
   </mat-sidenav-container>
 </div>
+
+<ng-template #linkTemplate let-link>
+  <div class="nav-item">
+    @if(link.matIcon){
+    <mat-icon style="margin-right: 8px">{{ link.matIcon }}</mat-icon>
+    }
+    <span>{{ link.label }}</span>
+  </div>
+</ng-template>

--- a/apps/picsa-apps/dashboard/src/app/app.component.ts
+++ b/apps/picsa-apps/dashboard/src/app/app.component.ts
@@ -19,10 +19,11 @@ export class AppComponent implements AfterViewInit {
   navLinks = DASHBOARD_NAV_LINKS;
 
   globalLinks: INavLink[] = [
-    // {
-    //   label: 'Deployments',
-    //   href: '/deployments',
-    // },
+    {
+      label: 'Deployments',
+      href: '/deployment',
+      matIcon: 'apps',
+    },
     // {
     //   label: 'Users',
     //   href: '/users',

--- a/apps/picsa-apps/dashboard/src/app/app.component.ts
+++ b/apps/picsa-apps/dashboard/src/app/app.component.ts
@@ -5,10 +5,11 @@ import { SupabaseService } from '@picsa/shared/services/core/supabase';
 
 import { DASHBOARD_NAV_LINKS, INavLink } from './data';
 import { DashboardMaterialModule } from './material.module';
+import { DeploymentSelectComponent } from './modules/deployment/components';
 
 @Component({
   standalone: true,
-  imports: [RouterModule, DashboardMaterialModule, CommonModule],
+  imports: [RouterModule, DashboardMaterialModule, DeploymentSelectComponent, CommonModule],
   selector: 'dashboard-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],

--- a/apps/picsa-apps/dashboard/src/app/app.routes.ts
+++ b/apps/picsa-apps/dashboard/src/app/app.routes.ts
@@ -16,9 +16,14 @@ export const appRoutes: Route[] = [
     loadChildren: () => import('./modules/climate/climate.module').then((m) => m.ClimateModule),
   },
   {
+    path: 'deployment',
+    loadChildren: () => import('./modules/deployment/deployment.module').then((m) => m.DeploymentModule),
+  },
+  {
     path: 'translations',
     loadChildren: () => import('./modules/translations/translations.module').then((m) => m.TranslationsPageModule),
   },
+
   // unmatched routes fallback to home
   {
     path: '**',

--- a/apps/picsa-apps/dashboard/src/app/modules/climate/types/db.d.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/climate/types/db.d.ts
@@ -7,6 +7,4 @@ export type IClimateProductInsert = Database['public']['Tables']['climate_produc
 export type IForecastRow = Database['public']['Tables']['climate_forecasts']['Row'];
 export type IForecastInsert = Database['public']['Tables']['climate_forecasts']['Insert'];
 
-export type IResourceRow = Database['public']['Tables']['resources']['Row'];
-
 export type IStationRow = Database['public']['Tables']['climate_stations']['Row'];

--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/components/deployment-select/deployment-select.component.html
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/components/deployment-select/deployment-select.component.html
@@ -1,0 +1,29 @@
+<button mat-button [matMenuTriggerFor]="menu" [style.visibility]="deployments.length > 0 ? 'visible' : 'hidden'">
+  @if(service.activeDeployment(); as deployment){
+  <ng-container *ngTemplateOutlet="deploymentSummary; context: { $implicit: deployment }"></ng-container>
+  } @else {
+  <div>Select Deployment</div>
+  }
+  <mat-icon iconPositionEnd>unfold_more</mat-icon>
+</button>
+
+<mat-menu #menu="matMenu">
+  @for(deployment of deployments; track deployment.id){
+  <button mat-menu-item class="menu-button" (click)="service.setActiveDeployment(deployment.id)">
+    <ng-container *ngTemplateOutlet="deploymentSummary; context: { $implicit: deployment }"></ng-container>
+  </button>
+
+  }
+</mat-menu>
+
+<ng-template #deploymentSummary let-deployment>
+  <div style="display: flex; align-items: center">
+    @if(deployment.icon_path){
+    <img
+      [src]="deployment.icon_path | storagePath"
+      style="height: 30px; width: 30px; object-fit: contain; margin-right: 8px"
+    />
+    }
+    <span>{{ deployment.label }}</span>
+  </div>
+</ng-template>

--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/components/deployment-select/deployment-select.component.spec.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/components/deployment-select/deployment-select.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DeploymentSelectComponent } from './deployment-select.component';
+
+describe('DeploymentSelectComponent', () => {
+  let component: DeploymentSelectComponent;
+  let fixture: ComponentFixture<DeploymentSelectComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeploymentSelectComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DeploymentSelectComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/components/deployment-select/deployment-select.component.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/components/deployment-select/deployment-select.component.ts
@@ -1,0 +1,38 @@
+import { CommonModule } from '@angular/common';
+import { Component, effect, OnInit } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
+import { StoragePathPipe } from '@picsa/shared/services/core/supabase';
+
+import { DeploymentDashboardService } from '../../deployment.service';
+import { IDeploymentRow } from '../../types';
+
+@Component({
+  selector: 'dashboard-deployment-select',
+  standalone: true,
+  imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, StoragePathPipe],
+  templateUrl: './deployment-select.component.html',
+  styleUrls: ['./deployment-select.component.scss'],
+})
+export class DeploymentSelectComponent implements OnInit {
+  public deployments: IDeploymentRow[] = [];
+  constructor(public service: DeploymentDashboardService) {
+    effect(() => {
+      const allDeployments = service.deployments();
+      this.deployments = allDeployments.sort(this.sortDeployments);
+    });
+  }
+
+  async ngOnInit() {
+    await this.service.ready();
+  }
+
+  // Sort deployments so global (no country code) appear on bottom of list, and otherwise
+  // group by variant
+  private sortDeployments(a: IDeploymentRow, b: IDeploymentRow) {
+    if (a.country_code === b.country_code) return a.variant! > b.variant! ? 1 : -1;
+    if (!a.country_code) return 1;
+    return -1;
+  }
+}

--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/components/index.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/components/index.ts
@@ -1,0 +1,1 @@
+export * from './deployment-select/deployment-select.component';

--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/deployment.module.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/deployment.module.ts
@@ -1,0 +1,19 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { DeploymentListComponent } from './pages/list/deployment-list.component';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule,
+    RouterModule.forChild([
+      {
+        path: '',
+        component: DeploymentListComponent,
+      },
+    ]),
+  ],
+})
+export class DeploymentModule {}

--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/deployment.service.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/deployment.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, signal } from '@angular/core';
+import { PicsaAsyncService } from '@picsa/shared/services/asyncService.service';
+import { PicsaNotificationService } from '@picsa/shared/services/core/notification.service';
+import { SupabaseService } from '@picsa/shared/services/core/supabase';
+
+import { IDeploymentRow } from './types';
+
+@Injectable({ providedIn: 'root' })
+export class DeploymentDashboardService extends PicsaAsyncService {
+  public readonly deployments = signal<IDeploymentRow[]>([]);
+
+  public get table() {
+    return this.supabaseService.db.table('deployments');
+  }
+
+  constructor(private supabaseService: SupabaseService, private notificationService: PicsaNotificationService) {
+    super();
+  }
+
+  public override async init() {
+    await this.supabaseService.ready();
+    await this.listDeployments();
+  }
+
+  private async listDeployments() {
+    const { data, error } = await this.table.select<'*', IDeploymentRow>('*');
+    if (error) {
+      throw error;
+    }
+    this.deployments.set(data);
+  }
+}

--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/deployment.service.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/deployment.service.ts
@@ -8,6 +8,7 @@ import { IDeploymentRow } from './types';
 @Injectable({ providedIn: 'root' })
 export class DeploymentDashboardService extends PicsaAsyncService {
   public readonly deployments = signal<IDeploymentRow[]>([]);
+  public readonly activeDeployment = signal<IDeploymentRow | null>(null);
 
   public get table() {
     return this.supabaseService.db.table('deployments');
@@ -20,6 +21,17 @@ export class DeploymentDashboardService extends PicsaAsyncService {
   public override async init() {
     await this.supabaseService.ready();
     await this.listDeployments();
+    this.loadStoredDeployment();
+  }
+
+  public async setActiveDeployment(id: string) {
+    // provide optimistic update
+    this.activeDeployment.set(this.deployments().find((d) => d.id === id) || null);
+    // provide server update
+    // TODO - subscribe to realtime updates
+    const { data } = await this.table.select<'*', IDeploymentRow>('*').eq('id', id).limit(1).single();
+    this.activeDeployment.set(data);
+    this.storeDeployment(data?.id);
   }
 
   private async listDeployments() {
@@ -28,5 +40,22 @@ export class DeploymentDashboardService extends PicsaAsyncService {
       throw error;
     }
     this.deployments.set(data);
+  }
+
+  /** Store deployment id to localstorage to persist across sessions */
+  private storeDeployment(id?: string) {
+    if (id) {
+      localStorage.setItem('picsa_dashboard_deployment', id);
+    } else {
+      localStorage.removeItem('picsa_dashboard_deployment');
+    }
+  }
+
+  /** Retrieve persisted deployment id from localstorage and load */
+  private loadStoredDeployment() {
+    const id = localStorage.getItem('picsa_dashboard_deployment');
+    if (id) {
+      this.setActiveDeployment(id);
+    }
   }
 }

--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/list/deployment-list.component.html
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/list/deployment-list.component.html
@@ -18,7 +18,7 @@
   <picsa-data-table
     [data]="data"
     [options]="tableOptions"
-    [valueTemplates]="{public,access_key_md5}"
+    [valueTemplates]="{public,access_key_md5,icon_path}"
   ></picsa-data-table>
 </ng-template>
 
@@ -29,4 +29,10 @@
 
 <ng-template #access_key_md5 let-access_key_md5>
   <mat-icon>{{ access_key_md5 ? 'password' : 'horizontal_rule' }}</mat-icon>
+</ng-template>
+
+<ng-template #icon_path let-icon_path>
+  @if(icon_path){
+  <img [src]="icon_path | storagePath" style="height: 50px" />
+  }
 </ng-template>

--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/list/deployment-list.component.html
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/list/deployment-list.component.html
@@ -1,0 +1,32 @@
+<div class="page-content">
+  <!-- Tabs to show table for each variant type -->
+  <mat-tab-group dynamicHeight mat-stretch-tabs="false" mat-align-tabs="start" preserveContent animationDuration="0ms">
+    <mat-tab label="Extension">
+      <ng-container *ngTemplateOutlet="deploymentTable; context: { $implicit: extension }"></ng-container>
+    </mat-tab>
+    <mat-tab label="Farmer">
+      <ng-container *ngTemplateOutlet="deploymentTable; context: { $implicit: farmer }"></ng-container>
+    </mat-tab>
+    <mat-tab label="Other">
+      <ng-container *ngTemplateOutlet="deploymentTable; context: { $implicit: other }"></ng-container>
+    </mat-tab>
+  </mat-tab-group>
+</div>
+
+<!-- General table template -->
+<ng-template #deploymentTable let-data>
+  <picsa-data-table
+    [data]="data"
+    [options]="tableOptions"
+    [valueTemplates]="{public,access_key_md5}"
+  ></picsa-data-table>
+</ng-template>
+
+<!-- Custom column templates -->
+<ng-template #public let-public>
+  <mat-icon>{{ public ? 'visibility' : 'visbility_off' }}</mat-icon>
+</ng-template>
+
+<ng-template #access_key_md5 let-access_key_md5>
+  <mat-icon>{{ access_key_md5 ? 'password' : 'horizontal_rule' }}</mat-icon>
+</ng-template>

--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/list/deployment-list.component.spec.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/list/deployment-list.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DeploymentListComponent } from './deployment-list.component';
+
+describe('DeploymentListComponent', () => {
+  let component: DeploymentListComponent;
+  let fixture: ComponentFixture<DeploymentListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeploymentListComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DeploymentListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/list/deployment-list.component.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/list/deployment-list.component.ts
@@ -1,0 +1,45 @@
+import { CommonModule } from '@angular/common';
+import { Component, effect, OnInit } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTabsModule } from '@angular/material/tabs';
+import { formatHeaderDefault, IDataTableOptions, PicsaDataTableComponent } from '@picsa/shared/features';
+
+import { DeploymentDashboardService } from '../../deployment.service';
+import { IDeploymentRow } from '../../types';
+
+const DISPLAYED_COLUMNS: (keyof IDeploymentRow)[] = ['country_code', 'label', 'public', 'access_key_md5'];
+
+@Component({
+  selector: 'dashboard-deployment-list',
+  standalone: true,
+  imports: [CommonModule, MatIconModule, MatTabsModule, PicsaDataTableComponent],
+  templateUrl: './deployment-list.component.html',
+  styleUrls: ['./deployment-list.component.scss'],
+})
+export class DeploymentListComponent implements OnInit {
+  public farmer: IDeploymentRow[] = [];
+  public extension: IDeploymentRow[] = [];
+  public other: IDeploymentRow[] = [];
+
+  public tableOptions: IDataTableOptions = {
+    search: false,
+    displayColumns: DISPLAYED_COLUMNS,
+    formatHeader: (value) => {
+      if (value === 'access_key_md5') return 'Restricted';
+      return formatHeaderDefault(value);
+    },
+  };
+
+  constructor(public service: DeploymentDashboardService) {
+    effect(() => {
+      const allDeployments = this.service.deployments();
+      this.farmer = allDeployments.filter((d) => d.variant === 'farmer');
+      this.extension = allDeployments.filter((d) => d.variant === 'extension');
+      this.other = allDeployments.filter((d) => d.variant === 'other');
+    });
+  }
+
+  async ngOnInit() {
+    await this.service.ready();
+  }
+}

--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/list/deployment-list.component.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/list/deployment-list.component.ts
@@ -3,16 +3,25 @@ import { Component, effect, OnInit } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTabsModule } from '@angular/material/tabs';
 import { formatHeaderDefault, IDataTableOptions, PicsaDataTableComponent } from '@picsa/shared/features';
+import { StoragePathPipe } from '@picsa/shared/services/core/supabase';
 
+import { DashboardStorageLinkComponent } from '../../../../components/storage-link/storage-link.component';
 import { DeploymentDashboardService } from '../../deployment.service';
 import { IDeploymentRow } from '../../types';
 
-const DISPLAYED_COLUMNS: (keyof IDeploymentRow)[] = ['country_code', 'label', 'public', 'access_key_md5'];
+const DISPLAYED_COLUMNS: (keyof IDeploymentRow)[] = ['country_code', 'label', 'public', 'access_key_md5', 'icon_path'];
 
 @Component({
   selector: 'dashboard-deployment-list',
   standalone: true,
-  imports: [CommonModule, MatIconModule, MatTabsModule, PicsaDataTableComponent],
+  imports: [
+    CommonModule,
+    DashboardStorageLinkComponent,
+    MatIconModule,
+    MatTabsModule,
+    PicsaDataTableComponent,
+    StoragePathPipe,
+  ],
   templateUrl: './deployment-list.component.html',
   styleUrls: ['./deployment-list.component.scss'],
 })
@@ -26,6 +35,7 @@ export class DeploymentListComponent implements OnInit {
     displayColumns: DISPLAYED_COLUMNS,
     formatHeader: (value) => {
       if (value === 'access_key_md5') return 'Restricted';
+      if (value === 'icon_path') return 'Icon';
       return formatHeaderDefault(value);
     },
   };

--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/list/deployment-list.component.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/list/deployment-list.component.ts
@@ -5,7 +5,6 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { formatHeaderDefault, IDataTableOptions, PicsaDataTableComponent } from '@picsa/shared/features';
 import { StoragePathPipe } from '@picsa/shared/services/core/supabase';
 
-import { DashboardStorageLinkComponent } from '../../../../components/storage-link/storage-link.component';
 import { DeploymentDashboardService } from '../../deployment.service';
 import { IDeploymentRow } from '../../types';
 
@@ -14,14 +13,7 @@ const DISPLAYED_COLUMNS: (keyof IDeploymentRow)[] = ['country_code', 'label', 'p
 @Component({
   selector: 'dashboard-deployment-list',
   standalone: true,
-  imports: [
-    CommonModule,
-    DashboardStorageLinkComponent,
-    MatIconModule,
-    MatTabsModule,
-    PicsaDataTableComponent,
-    StoragePathPipe,
-  ],
+  imports: [CommonModule, MatIconModule, MatTabsModule, PicsaDataTableComponent, StoragePathPipe],
   templateUrl: './deployment-list.component.html',
   styleUrls: ['./deployment-list.component.scss'],
 })

--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/types/index.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/types/index.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import type { Database } from '@picsa/server-types';
+
+export type IDeploymentRow = Database['public']['Tables']['deployments']['Row'];

--- a/apps/picsa-apps/dashboard/src/app/modules/resources/pages/create/resource-create.component.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/resources/pages/create/resource-create.component.ts
@@ -11,9 +11,9 @@ import {
 import { IStorageEntry } from '@picsa/shared/services/core/supabase/services/supabase-storage.service';
 
 import { DashboardMaterialModule } from '../../../../material.module';
-import { IResourceRow } from '../../../climate/types';
 import { DashboardResourcesStorageLinkComponent } from '../../components/storage-link/storage-link.component';
 import { ResourcesDashboardService } from '../../resources.service';
+import { IResourceRow } from '../../types';
 
 @Component({
   selector: 'dashboard-resource-create',

--- a/apps/picsa-apps/dashboard/src/app/modules/resources/resources.service.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/resources/resources.service.ts
@@ -7,7 +7,7 @@ import { SupabaseService } from '@picsa/shared/services/core/supabase';
 import { IStorageEntry } from '@picsa/shared/services/core/supabase/services/supabase-storage.service';
 import { arrayToHashmap } from '@picsa/utils';
 
-import { IResourceRow } from '../climate/types';
+import { IResourceRow } from './types';
 
 export interface IResourceStorageEntry extends IStorageEntry {
   /** Url generated when upload to public bucket (will always be populated, even if bucket not public) */

--- a/apps/picsa-apps/dashboard/src/app/modules/resources/types/index.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/resources/types/index.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import type { Database } from '@picsa/server-types';
+
+export type IResourceRow = Database['public']['Tables']['resources']['Row'];

--- a/apps/picsa-server/supabase/data/deployments_rows.csv
+++ b/apps/picsa-server/supabase/data/deployments_rows.csv
@@ -1,0 +1,9 @@
+id,country_code,label,org_code,configuration,variant,access_key_md5,public
+demo_admin,,Admin Demo,demo,{},extension,,true
+global,,Global,,{},extension,,true
+global_translators,,Translators,translators,{},extension,,true
+mw_extension,mw,Extension,,{},extension,,true
+mw_farmer,mw,Farmer,,{},farmer,,true
+zm_extension,zm,Zambia,,{},extension,,true
+zm_extension_demo,,ZM Admin Demo,demo,{},extension,,true
+zm_farmer,zm,Farmer,,{},farmer,,true

--- a/apps/picsa-server/supabase/data/deployments_rows.csv
+++ b/apps/picsa-server/supabase/data/deployments_rows.csv
@@ -1,9 +1,10 @@
-id,country_code,label,configuration,variant,access_key_md5,public
-demo_admin,,Admin Demo,{},other,,true
-global,,Global,{},extension,,true
-global_translators,,Translators,{},other,,true
-mw_extension,mw,Extension,{},extension,,true
-mw_farmer,mw,Farmer,{},farmer,,true
-zm_extension,zm,Zambia,{},extension,,true
-zm_extension_demo,zm,ZM Admin Demo,{},other,,true
-zm_farmer,zm,Farmer,{},farmer,,true
+id,country_code,label,configuration,variant,access_key_md5,public,icon_path
+demo_admin,,Admin Demo,{},other,,true,global/images/flags/global.svg
+global,,Extension,{},extension,,true,global/images/flags/global.svg
+global_translators,,Translators,{},other,,true,global/images/flags/global.svg
+mw_admin_demo,mw,Admin Demo,{},other,,true,global/images/flags/mw.svg
+mw_extension,mw,Extension,{},extension,,true,global/images/flags/mw.svg
+mw_farmer,mw,Farmer,{},farmer,,true,global/images/flags/mw.svg
+zm_admin_demo,zm,Admin Demo,{},other,,true,global/images/flags/zm.svg
+zm_extension,zm,Extension,{},extension,,true,global/images/flags/zm.svg
+zm_farmer,zm,Farmer,{},farmer,,true,global/images/flags/zm.svg

--- a/apps/picsa-server/supabase/data/deployments_rows.csv
+++ b/apps/picsa-server/supabase/data/deployments_rows.csv
@@ -1,9 +1,9 @@
-id,country_code,label,org_code,configuration,variant,access_key_md5,public
-demo_admin,,Admin Demo,demo,{},extension,,true
-global,,Global,,{},extension,,true
-global_translators,,Translators,translators,{},extension,,true
-mw_extension,mw,Extension,,{},extension,,true
-mw_farmer,mw,Farmer,,{},farmer,,true
-zm_extension,zm,Zambia,,{},extension,,true
-zm_extension_demo,,ZM Admin Demo,demo,{},extension,,true
-zm_farmer,zm,Farmer,,{},farmer,,true
+id,country_code,label,configuration,variant,access_key_md5,public
+demo_admin,,Admin Demo,{},other,,true
+global,,Global,{},extension,,true
+global_translators,,Translators,{},other,,true
+mw_extension,mw,Extension,{},extension,,true
+mw_farmer,mw,Farmer,{},farmer,,true
+zm_extension,zm,Zambia,{},extension,,true
+zm_extension_demo,zm,ZM Admin Demo,{},other,,true
+zm_farmer,zm,Farmer,{},farmer,,true

--- a/apps/picsa-server/supabase/migrations/20240228005631_storage_path_column.sql
+++ b/apps/picsa-server/supabase/migrations/20240228005631_storage_path_column.sql
@@ -1,0 +1,9 @@
+-- Add fully qualified storage paths to storage.objects table (bucket + name)
+AlTER TABLE storage.objects add column 
+"path" text GENERATED ALWAYS AS (bucket_id || '/' || name) STORED
+;
+
+-- Set unique constraint on qualified storage path
+ALTER TABLE storage.objects add constraint 
+"storage_path_key" unique (path)
+;

--- a/apps/picsa-server/supabase/migrations/20240228005632_deployments_table_add.sql
+++ b/apps/picsa-server/supabase/migrations/20240228005632_deployments_table_add.sql
@@ -7,9 +7,11 @@ create table
     variant text null default 'extension'::text,
     access_key_md5 text null,
     public boolean not null default true,
+    icon_path text null,
     constraint deployments_pkey primary key (id),
+    constraint deployments_icon_path_fkey foreign key (icon_path) references storage.objects (path),
     constraint deployments_variant_check check (
-       (
+      (
         (variant = 'farmer'::text)
         or (variant = 'extension'::text)
         or (variant = 'other'::text)

--- a/apps/picsa-server/supabase/migrations/20240228005632_deployments_table_add.sql
+++ b/apps/picsa-server/supabase/migrations/20240228005632_deployments_table_add.sql
@@ -1,0 +1,18 @@
+create table
+  public.deployments (
+    id text not null,
+    country_code text null,
+    label text not null,
+    org_code text null,
+    configuration jsonb not null default '{}'::jsonb,
+    variant text null default 'extension'::text,
+    access_key_md5 text null,
+    public boolean not null default true,
+    constraint deployments_pkey primary key (id),
+    constraint deployments_variant_check check (
+      (
+        (variant = 'farmer'::text)
+        or (variant = 'extension'::text)
+      )
+    )
+  ) tablespace pg_default;

--- a/apps/picsa-server/supabase/migrations/20240228005632_deployments_table_add.sql
+++ b/apps/picsa-server/supabase/migrations/20240228005632_deployments_table_add.sql
@@ -9,7 +9,7 @@ create table
     public boolean not null default true,
     icon_path text null,
     constraint deployments_pkey primary key (id),
-    constraint deployments_icon_path_fkey foreign key (icon_path) references storage.objects (path),
+    constraint deployments_icon_path_fkey foreign key (icon_path) references storage.objects (path) on delete set null,
     constraint deployments_variant_check check (
       (
         (variant = 'farmer'::text)

--- a/apps/picsa-server/supabase/migrations/20240228005632_deployments_table_add.sql
+++ b/apps/picsa-server/supabase/migrations/20240228005632_deployments_table_add.sql
@@ -3,16 +3,16 @@ create table
     id text not null,
     country_code text null,
     label text not null,
-    org_code text null,
     configuration jsonb not null default '{}'::jsonb,
     variant text null default 'extension'::text,
     access_key_md5 text null,
     public boolean not null default true,
     constraint deployments_pkey primary key (id),
     constraint deployments_variant_check check (
-      (
+       (
         (variant = 'farmer'::text)
         or (variant = 'extension'::text)
+        or (variant = 'other'::text)
       )
     )
   ) tablespace pg_default;

--- a/apps/picsa-server/supabase/types/index.ts
+++ b/apps/picsa-server/supabase/types/index.ts
@@ -1,548 +1,577 @@
-export type Json =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: Json | undefined }
-  | Json[]
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
 
 export interface Database {
   graphql_public: {
     Tables: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
       graphql: {
         Args: {
-          operationName?: string
-          query?: string
-          variables?: Json
-          extensions?: Json
-        }
-        Returns: Json
-      }
-    }
+          operationName?: string;
+          query?: string;
+          variables?: Json;
+          extensions?: Json;
+        };
+        Returns: Json;
+      };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
+      [_ in never]: never;
+    };
+  };
   public: {
     Tables: {
       climate_forecasts: {
         Row: {
-          country_code: string | null
-          date_modified: string
-          district: string | null
-          filename: string
-          id: string
-          language_code: string | null
-          storage_file: string | null
-          type: string | null
-        }
+          country_code: string | null;
+          date_modified: string;
+          district: string | null;
+          filename: string;
+          id: string;
+          language_code: string | null;
+          storage_file: string | null;
+          type: string | null;
+        };
         Insert: {
-          country_code?: string | null
-          date_modified: string
-          district?: string | null
-          filename: string
-          id: string
-          language_code?: string | null
-          storage_file?: string | null
-          type?: string | null
-        }
+          country_code?: string | null;
+          date_modified: string;
+          district?: string | null;
+          filename: string;
+          id: string;
+          language_code?: string | null;
+          storage_file?: string | null;
+          type?: string | null;
+        };
         Update: {
-          country_code?: string | null
-          date_modified?: string
-          district?: string | null
-          filename?: string
-          id?: string
-          language_code?: string | null
-          storage_file?: string | null
-          type?: string | null
-        }
+          country_code?: string | null;
+          date_modified?: string;
+          district?: string | null;
+          filename?: string;
+          id?: string;
+          language_code?: string | null;
+          storage_file?: string | null;
+          type?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "climate_forecasts_storage_file_fkey"
-            columns: ["storage_file"]
-            referencedRelation: "objects"
-            referencedColumns: ["id"]
+            foreignKeyName: 'climate_forecasts_storage_file_fkey';
+            columns: ['storage_file'];
+            referencedRelation: 'objects';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "climate_forecasts_storage_file_fkey"
-            columns: ["storage_file"]
-            referencedRelation: "storage_objects"
-            referencedColumns: ["id"]
+            foreignKeyName: 'climate_forecasts_storage_file_fkey';
+            columns: ['storage_file'];
+            referencedRelation: 'storage_objects';
+            referencedColumns: ['id'];
           }
-        ]
-      }
+        ];
+      };
       climate_products: {
         Row: {
-          created_at: string
-          data: Json
-          station_id: number
-          type: string
-        }
+          created_at: string;
+          data: Json;
+          station_id: number;
+          type: string;
+        };
         Insert: {
-          created_at?: string
-          data: Json
-          station_id: number
-          type: string
-        }
+          created_at?: string;
+          data: Json;
+          station_id: number;
+          type: string;
+        };
         Update: {
-          created_at?: string
-          data?: Json
-          station_id?: number
-          type?: string
-        }
+          created_at?: string;
+          data?: Json;
+          station_id?: number;
+          type?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "climate_products_station_id_fkey"
-            columns: ["station_id"]
-            referencedRelation: "climate_stations"
-            referencedColumns: ["station_id"]
+            foreignKeyName: 'climate_products_station_id_fkey';
+            columns: ['station_id'];
+            referencedRelation: 'climate_stations';
+            referencedColumns: ['station_id'];
           }
-        ]
-      }
+        ];
+      };
       climate_stations: {
         Row: {
-          country_code: string | null
-          district: string | null
-          elevation: number | null
-          latitude: number | null
-          longitude: number | null
-          station_id: number
-          station_name: string | null
-        }
+          country_code: string | null;
+          district: string | null;
+          elevation: number | null;
+          latitude: number | null;
+          longitude: number | null;
+          station_id: number;
+          station_name: string | null;
+        };
         Insert: {
-          country_code?: string | null
-          district?: string | null
-          elevation?: number | null
-          latitude?: number | null
-          longitude?: number | null
-          station_id?: number
-          station_name?: string | null
-        }
+          country_code?: string | null;
+          district?: string | null;
+          elevation?: number | null;
+          latitude?: number | null;
+          longitude?: number | null;
+          station_id?: number;
+          station_name?: string | null;
+        };
         Update: {
-          country_code?: string | null
-          district?: string | null
-          elevation?: number | null
-          latitude?: number | null
-          longitude?: number | null
-          station_id?: number
-          station_name?: string | null
-        }
-        Relationships: []
-      }
+          country_code?: string | null;
+          district?: string | null;
+          elevation?: number | null;
+          latitude?: number | null;
+          longitude?: number | null;
+          station_id?: number;
+          station_name?: string | null;
+        };
+        Relationships: [];
+      };
+      deployments: {
+        Row: {
+          access_key_md5: string | null;
+          configuration: Json;
+          country_code: string | null;
+          id: string;
+          label: string;
+          org_code: string | null;
+          public: boolean;
+          variant: string | null;
+        };
+        Insert: {
+          access_key_md5?: string | null;
+          configuration?: Json;
+          country_code?: string | null;
+          id: string;
+          label: string;
+          org_code?: string | null;
+          public?: boolean;
+          variant?: string | null;
+        };
+        Update: {
+          access_key_md5?: string | null;
+          configuration?: Json;
+          country_code?: string | null;
+          id?: string;
+          label?: string;
+          org_code?: string | null;
+          public?: boolean;
+          variant?: string | null;
+        };
+        Relationships: [];
+      };
       kobo_sync: {
         Row: {
-          _created: string
-          _id: string
-          _modified: string
-          enketo_entry: Json | null
-          kobo_form_id: string | null
-          kobo_sync_required: boolean | null
-          kobo_sync_status: number | null
-          kobo_sync_time: string | null
-          kobo_uuid: string | null
-          operation: string
-        }
+          _created: string;
+          _id: string;
+          _modified: string;
+          enketo_entry: Json | null;
+          kobo_form_id: string | null;
+          kobo_sync_required: boolean | null;
+          kobo_sync_status: number | null;
+          kobo_sync_time: string | null;
+          kobo_uuid: string | null;
+          operation: string;
+        };
         Insert: {
-          _created?: string
-          _id: string
-          _modified?: string
-          enketo_entry?: Json | null
-          kobo_form_id?: string | null
-          kobo_sync_required?: boolean | null
-          kobo_sync_status?: number | null
-          kobo_sync_time?: string | null
-          kobo_uuid?: string | null
-          operation: string
-        }
+          _created?: string;
+          _id: string;
+          _modified?: string;
+          enketo_entry?: Json | null;
+          kobo_form_id?: string | null;
+          kobo_sync_required?: boolean | null;
+          kobo_sync_status?: number | null;
+          kobo_sync_time?: string | null;
+          kobo_uuid?: string | null;
+          operation: string;
+        };
         Update: {
-          _created?: string
-          _id?: string
-          _modified?: string
-          enketo_entry?: Json | null
-          kobo_form_id?: string | null
-          kobo_sync_required?: boolean | null
-          kobo_sync_status?: number | null
-          kobo_sync_time?: string | null
-          kobo_uuid?: string | null
-          operation?: string
-        }
-        Relationships: []
-      }
+          _created?: string;
+          _id?: string;
+          _modified?: string;
+          enketo_entry?: Json | null;
+          kobo_form_id?: string | null;
+          kobo_sync_required?: boolean | null;
+          kobo_sync_status?: number | null;
+          kobo_sync_time?: string | null;
+          kobo_uuid?: string | null;
+          operation?: string;
+        };
+        Relationships: [];
+      };
       monitoring_tool_submissions: {
         Row: {
-          _app_user_id: string
-          _attachments: Json
-          _created: string
-          _deleted: boolean
-          _id: string
-          _modified: string
-          enketoEntry: Json
-          formId: string
-          json: Json
-        }
+          _app_user_id: string;
+          _attachments: Json;
+          _created: string;
+          _deleted: boolean;
+          _id: string;
+          _modified: string;
+          enketoEntry: Json;
+          formId: string;
+          json: Json;
+        };
         Insert: {
-          _app_user_id: string
-          _attachments: Json
-          _created?: string
-          _deleted?: boolean
-          _id: string
-          _modified?: string
-          enketoEntry: Json
-          formId: string
-          json: Json
-        }
+          _app_user_id: string;
+          _attachments: Json;
+          _created?: string;
+          _deleted?: boolean;
+          _id: string;
+          _modified?: string;
+          enketoEntry: Json;
+          formId: string;
+          json: Json;
+        };
         Update: {
-          _app_user_id?: string
-          _attachments?: Json
-          _created?: string
-          _deleted?: boolean
-          _id?: string
-          _modified?: string
-          enketoEntry?: Json
-          formId?: string
-          json?: Json
-        }
-        Relationships: []
-      }
+          _app_user_id?: string;
+          _attachments?: Json;
+          _created?: string;
+          _deleted?: boolean;
+          _id?: string;
+          _modified?: string;
+          enketoEntry?: Json;
+          formId?: string;
+          json?: Json;
+        };
+        Relationships: [];
+      };
       resources: {
         Row: {
-          created_at: string
-          description: string
-          id: string
-          modified_at: string
-          storage_cover: string | null
-          storage_file: string | null
-          title: string | null
-          type: string
-        }
+          created_at: string;
+          description: string;
+          id: string;
+          modified_at: string;
+          storage_cover: string | null;
+          storage_file: string | null;
+          title: string | null;
+          type: string;
+        };
         Insert: {
-          created_at?: string
-          description?: string
-          id?: string
-          modified_at?: string
-          storage_cover?: string | null
-          storage_file?: string | null
-          title?: string | null
-          type: string
-        }
+          created_at?: string;
+          description?: string;
+          id?: string;
+          modified_at?: string;
+          storage_cover?: string | null;
+          storage_file?: string | null;
+          title?: string | null;
+          type: string;
+        };
         Update: {
-          created_at?: string
-          description?: string
-          id?: string
-          modified_at?: string
-          storage_cover?: string | null
-          storage_file?: string | null
-          title?: string | null
-          type?: string
-        }
+          created_at?: string;
+          description?: string;
+          id?: string;
+          modified_at?: string;
+          storage_cover?: string | null;
+          storage_file?: string | null;
+          title?: string | null;
+          type?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "resources_storage_cover_fkey"
-            columns: ["storage_cover"]
-            referencedRelation: "objects"
-            referencedColumns: ["id"]
+            foreignKeyName: 'resources_storage_cover_fkey';
+            columns: ['storage_cover'];
+            referencedRelation: 'objects';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "resources_storage_cover_fkey"
-            columns: ["storage_cover"]
-            referencedRelation: "storage_objects"
-            referencedColumns: ["id"]
+            foreignKeyName: 'resources_storage_cover_fkey';
+            columns: ['storage_cover'];
+            referencedRelation: 'storage_objects';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "resources_storage_file_fkey"
-            columns: ["storage_file"]
-            referencedRelation: "objects"
-            referencedColumns: ["id"]
+            foreignKeyName: 'resources_storage_file_fkey';
+            columns: ['storage_file'];
+            referencedRelation: 'objects';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "resources_storage_file_fkey"
-            columns: ["storage_file"]
-            referencedRelation: "storage_objects"
-            referencedColumns: ["id"]
+            foreignKeyName: 'resources_storage_file_fkey';
+            columns: ['storage_file'];
+            referencedRelation: 'storage_objects';
+            referencedColumns: ['id'];
           }
-        ]
-      }
+        ];
+      };
       translations: {
         Row: {
-          context: string | null
-          created_at: string
-          en: string
-          id: string
-          ke_sw: string | null
-          mw_ny: string | null
-          tj_tg: string | null
-          tool: string
-          zm_ny: string | null
-        }
+          context: string | null;
+          created_at: string;
+          en: string;
+          id: string;
+          ke_sw: string | null;
+          mw_ny: string | null;
+          tj_tg: string | null;
+          tool: string;
+          zm_ny: string | null;
+        };
         Insert: {
-          context?: string | null
-          created_at?: string
-          en: string
-          id: string
-          ke_sw?: string | null
-          mw_ny?: string | null
-          tj_tg?: string | null
-          tool: string
-          zm_ny?: string | null
-        }
+          context?: string | null;
+          created_at?: string;
+          en: string;
+          id: string;
+          ke_sw?: string | null;
+          mw_ny?: string | null;
+          tj_tg?: string | null;
+          tool: string;
+          zm_ny?: string | null;
+        };
         Update: {
-          context?: string | null
-          created_at?: string
-          en?: string
-          id?: string
-          ke_sw?: string | null
-          mw_ny?: string | null
-          tj_tg?: string | null
-          tool?: string
-          zm_ny?: string | null
-        }
-        Relationships: []
-      }
-    }
+          context?: string | null;
+          created_at?: string;
+          en?: string;
+          id?: string;
+          ke_sw?: string | null;
+          mw_ny?: string | null;
+          tj_tg?: string | null;
+          tool?: string;
+          zm_ny?: string | null;
+        };
+        Relationships: [];
+      };
+    };
     Views: {
       storage_objects: {
         Row: {
-          bucket_id: string | null
-          created_at: string | null
-          id: string | null
-          last_accessed_at: string | null
-          metadata: Json | null
-          name: string | null
-          owner: string | null
-          path_tokens: string[] | null
-          updated_at: string | null
-          version: string | null
-        }
+          bucket_id: string | null;
+          created_at: string | null;
+          id: string | null;
+          last_accessed_at: string | null;
+          metadata: Json | null;
+          name: string | null;
+          owner: string | null;
+          owner_id: string | null;
+          path_tokens: string[] | null;
+          updated_at: string | null;
+          version: string | null;
+        };
         Insert: {
-          bucket_id?: string | null
-          created_at?: string | null
-          id?: string | null
-          last_accessed_at?: string | null
-          metadata?: Json | null
-          name?: string | null
-          owner?: string | null
-          path_tokens?: string[] | null
-          updated_at?: string | null
-          version?: string | null
-        }
+          bucket_id?: string | null;
+          created_at?: string | null;
+          id?: string | null;
+          last_accessed_at?: string | null;
+          metadata?: Json | null;
+          name?: string | null;
+          owner?: string | null;
+          owner_id?: string | null;
+          path_tokens?: string[] | null;
+          updated_at?: string | null;
+          version?: string | null;
+        };
         Update: {
-          bucket_id?: string | null
-          created_at?: string | null
-          id?: string | null
-          last_accessed_at?: string | null
-          metadata?: Json | null
-          name?: string | null
-          owner?: string | null
-          path_tokens?: string[] | null
-          updated_at?: string | null
-          version?: string | null
-        }
+          bucket_id?: string | null;
+          created_at?: string | null;
+          id?: string | null;
+          last_accessed_at?: string | null;
+          metadata?: Json | null;
+          name?: string | null;
+          owner?: string | null;
+          owner_id?: string | null;
+          path_tokens?: string[] | null;
+          updated_at?: string | null;
+          version?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "objects_bucketId_fkey"
-            columns: ["bucket_id"]
-            referencedRelation: "buckets"
-            referencedColumns: ["id"]
+            foreignKeyName: 'objects_bucketId_fkey';
+            columns: ['bucket_id'];
+            referencedRelation: 'buckets';
+            referencedColumns: ['id'];
           }
-        ]
-      }
-    }
+        ];
+      };
+    };
     Functions: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
+      [_ in never]: never;
+    };
+  };
   storage: {
     Tables: {
       buckets: {
         Row: {
-          allowed_mime_types: string[] | null
-          avif_autodetection: boolean | null
-          created_at: string | null
-          file_size_limit: number | null
-          id: string
-          name: string
-          owner: string | null
-          owner_id: string | null
-          public: boolean | null
-          updated_at: string | null
-        }
+          allowed_mime_types: string[] | null;
+          avif_autodetection: boolean | null;
+          created_at: string | null;
+          file_size_limit: number | null;
+          id: string;
+          name: string;
+          owner: string | null;
+          owner_id: string | null;
+          public: boolean | null;
+          updated_at: string | null;
+        };
         Insert: {
-          allowed_mime_types?: string[] | null
-          avif_autodetection?: boolean | null
-          created_at?: string | null
-          file_size_limit?: number | null
-          id: string
-          name: string
-          owner?: string | null
-          owner_id?: string | null
-          public?: boolean | null
-          updated_at?: string | null
-        }
+          allowed_mime_types?: string[] | null;
+          avif_autodetection?: boolean | null;
+          created_at?: string | null;
+          file_size_limit?: number | null;
+          id: string;
+          name: string;
+          owner?: string | null;
+          owner_id?: string | null;
+          public?: boolean | null;
+          updated_at?: string | null;
+        };
         Update: {
-          allowed_mime_types?: string[] | null
-          avif_autodetection?: boolean | null
-          created_at?: string | null
-          file_size_limit?: number | null
-          id?: string
-          name?: string
-          owner?: string | null
-          owner_id?: string | null
-          public?: boolean | null
-          updated_at?: string | null
-        }
-        Relationships: []
-      }
+          allowed_mime_types?: string[] | null;
+          avif_autodetection?: boolean | null;
+          created_at?: string | null;
+          file_size_limit?: number | null;
+          id?: string;
+          name?: string;
+          owner?: string | null;
+          owner_id?: string | null;
+          public?: boolean | null;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
       migrations: {
         Row: {
-          executed_at: string | null
-          hash: string
-          id: number
-          name: string
-        }
+          executed_at: string | null;
+          hash: string;
+          id: number;
+          name: string;
+        };
         Insert: {
-          executed_at?: string | null
-          hash: string
-          id: number
-          name: string
-        }
+          executed_at?: string | null;
+          hash: string;
+          id: number;
+          name: string;
+        };
         Update: {
-          executed_at?: string | null
-          hash?: string
-          id?: number
-          name?: string
-        }
-        Relationships: []
-      }
+          executed_at?: string | null;
+          hash?: string;
+          id?: number;
+          name?: string;
+        };
+        Relationships: [];
+      };
       objects: {
         Row: {
-          bucket_id: string | null
-          created_at: string | null
-          id: string
-          last_accessed_at: string | null
-          metadata: Json | null
-          name: string | null
-          owner: string | null
-          owner_id: string | null
-          path_tokens: string[] | null
-          updated_at: string | null
-          version: string | null
-        }
+          bucket_id: string | null;
+          created_at: string | null;
+          id: string;
+          last_accessed_at: string | null;
+          metadata: Json | null;
+          name: string | null;
+          owner: string | null;
+          owner_id: string | null;
+          path_tokens: string[] | null;
+          updated_at: string | null;
+          version: string | null;
+        };
         Insert: {
-          bucket_id?: string | null
-          created_at?: string | null
-          id?: string
-          last_accessed_at?: string | null
-          metadata?: Json | null
-          name?: string | null
-          owner?: string | null
-          owner_id?: string | null
-          path_tokens?: string[] | null
-          updated_at?: string | null
-          version?: string | null
-        }
+          bucket_id?: string | null;
+          created_at?: string | null;
+          id?: string;
+          last_accessed_at?: string | null;
+          metadata?: Json | null;
+          name?: string | null;
+          owner?: string | null;
+          owner_id?: string | null;
+          path_tokens?: string[] | null;
+          updated_at?: string | null;
+          version?: string | null;
+        };
         Update: {
-          bucket_id?: string | null
-          created_at?: string | null
-          id?: string
-          last_accessed_at?: string | null
-          metadata?: Json | null
-          name?: string | null
-          owner?: string | null
-          owner_id?: string | null
-          path_tokens?: string[] | null
-          updated_at?: string | null
-          version?: string | null
-        }
+          bucket_id?: string | null;
+          created_at?: string | null;
+          id?: string;
+          last_accessed_at?: string | null;
+          metadata?: Json | null;
+          name?: string | null;
+          owner?: string | null;
+          owner_id?: string | null;
+          path_tokens?: string[] | null;
+          updated_at?: string | null;
+          version?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "objects_bucketId_fkey"
-            columns: ["bucket_id"]
-            referencedRelation: "buckets"
-            referencedColumns: ["id"]
+            foreignKeyName: 'objects_bucketId_fkey';
+            columns: ['bucket_id'];
+            referencedRelation: 'buckets';
+            referencedColumns: ['id'];
           }
-        ]
-      }
-    }
+        ];
+      };
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
       can_insert_object: {
         Args: {
-          bucketid: string
-          name: string
-          owner: string
-          metadata: Json
-        }
-        Returns: undefined
-      }
+          bucketid: string;
+          name: string;
+          owner: string;
+          metadata: Json;
+        };
+        Returns: undefined;
+      };
       extension: {
         Args: {
-          name: string
-        }
-        Returns: string
-      }
+          name: string;
+        };
+        Returns: string;
+      };
       filename: {
         Args: {
-          name: string
-        }
-        Returns: string
-      }
+          name: string;
+        };
+        Returns: string;
+      };
       foldername: {
         Args: {
-          name: string
-        }
-        Returns: unknown
-      }
+          name: string;
+        };
+        Returns: unknown;
+      };
       get_size_by_bucket: {
-        Args: Record<PropertyKey, never>
+        Args: Record<PropertyKey, never>;
         Returns: {
-          size: number
-          bucket_id: string
-        }[]
-      }
+          size: number;
+          bucket_id: string;
+        }[];
+      };
       search: {
         Args: {
-          prefix: string
-          bucketname: string
-          limits?: number
-          levels?: number
-          offsets?: number
-          search?: string
-          sortcolumn?: string
-          sortorder?: string
-        }
+          prefix: string;
+          bucketname: string;
+          limits?: number;
+          levels?: number;
+          offsets?: number;
+          search?: string;
+          sortcolumn?: string;
+          sortorder?: string;
+        };
         Returns: {
-          name: string
-          id: string
-          updated_at: string
-          created_at: string
-          last_accessed_at: string
-          metadata: Json
-        }[]
-      }
-    }
+          name: string;
+          id: string;
+          updated_at: string;
+          created_at: string;
+          last_accessed_at: string;
+          metadata: Json;
+        }[];
+      };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
+      [_ in never]: never;
+    };
+  };
 }
-

--- a/apps/picsa-server/supabase/types/index.ts
+++ b/apps/picsa-server/supabase/types/index.ts
@@ -137,6 +137,7 @@ export interface Database {
           access_key_md5: string | null;
           configuration: Json;
           country_code: string | null;
+          icon_path: string | null;
           id: string;
           label: string;
           public: boolean;
@@ -146,6 +147,7 @@ export interface Database {
           access_key_md5?: string | null;
           configuration?: Json;
           country_code?: string | null;
+          icon_path?: string | null;
           id: string;
           label: string;
           public?: boolean;
@@ -155,12 +157,20 @@ export interface Database {
           access_key_md5?: string | null;
           configuration?: Json;
           country_code?: string | null;
+          icon_path?: string | null;
           id?: string;
           label?: string;
           public?: boolean;
           variant?: string | null;
         };
-        Relationships: [];
+        Relationships: [
+          {
+            foreignKeyName: 'deployments_icon_path_fkey';
+            columns: ['icon_path'];
+            referencedRelation: 'objects';
+            referencedColumns: ['path'];
+          }
+        ];
       };
       kobo_sync: {
         Row: {
@@ -465,6 +475,7 @@ export interface Database {
           name: string | null;
           owner: string | null;
           owner_id: string | null;
+          path: string | null;
           path_tokens: string[] | null;
           updated_at: string | null;
           version: string | null;
@@ -478,6 +489,7 @@ export interface Database {
           name?: string | null;
           owner?: string | null;
           owner_id?: string | null;
+          path?: string | null;
           path_tokens?: string[] | null;
           updated_at?: string | null;
           version?: string | null;
@@ -491,6 +503,7 @@ export interface Database {
           name?: string | null;
           owner?: string | null;
           owner_id?: string | null;
+          path?: string | null;
           path_tokens?: string[] | null;
           updated_at?: string | null;
           version?: string | null;

--- a/apps/picsa-server/supabase/types/index.ts
+++ b/apps/picsa-server/supabase/types/index.ts
@@ -139,7 +139,6 @@ export interface Database {
           country_code: string | null;
           id: string;
           label: string;
-          org_code: string | null;
           public: boolean;
           variant: string | null;
         };
@@ -149,7 +148,6 @@ export interface Database {
           country_code?: string | null;
           id: string;
           label: string;
-          org_code?: string | null;
           public?: boolean;
           variant?: string | null;
         };
@@ -159,7 +157,6 @@ export interface Database {
           country_code?: string | null;
           id?: string;
           label?: string;
-          org_code?: string | null;
           public?: boolean;
           variant?: string | null;
         };

--- a/libs/shared/src/features/data-table/data-table.component.ts
+++ b/libs/shared/src/features/data-table/data-table.component.ts
@@ -38,6 +38,9 @@ export interface IDataTableOptions {
   handleRowClick?: (row: any) => void;
 }
 
+/** Default header formatter. Splits '_' column names and capitalises each word */
+export const formatHeaderDefault = (v: string) => v.split('_').map(capitalise).join(' ');
+
 /**
  * Simple pipe that allows providing a custom formatter function,
  * used to modify cell values in a pure way
@@ -120,7 +123,7 @@ export class PicsaDataTableComponent implements OnChanges {
     search: true,
     sort: true,
     handleRowClick: () => null,
-    formatHeader: (v) => v.split('_').map(capitalise).join(' '),
+    formatHeader: formatHeaderDefault,
   };
 
   public dataSource: MatTableDataSource<any>;

--- a/libs/shared/src/services/core/supabase/index.ts
+++ b/libs/shared/src/services/core/supabase/index.ts
@@ -1,2 +1,3 @@
 export * from './components';
+export * from './pipes';
 export * from './supabase.service';

--- a/libs/shared/src/services/core/supabase/pipes/index.ts
+++ b/libs/shared/src/services/core/supabase/pipes/index.ts
@@ -1,0 +1,1 @@
+export * from './storagePath.pipe';

--- a/libs/shared/src/services/core/supabase/pipes/storagePath.pipe.ts
+++ b/libs/shared/src/services/core/supabase/pipes/storagePath.pipe.ts
@@ -1,0 +1,23 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+import { SupabaseStorageService } from '../services/supabase-storage.service';
+
+/**
+ * Convert a fully qualified storage path to public url
+ * @example
+ * ```
+ * <img [src]="'my_bucket/folder/image.png' | storagePath "
+ * ```
+ */
+@Pipe({
+  name: 'storagePath',
+  standalone: true,
+})
+export class StoragePathPipe implements PipeTransform {
+  constructor(private storageService: SupabaseStorageService) {}
+  transform(path: string): string {
+    const [bucketId, ...pathSegments] = path.split('/');
+    const objectPath = pathSegments.join('/');
+    return this.storageService.getPublicLink(bucketId, objectPath);
+  }
+}


### PR DESCRIPTION
## Description
**Main Changes**
The dashboard will use a _deployments_ system to allow for different data to be used within different versions of the app. This includes separation across countries, as well as specific variations within a county (e.g. extension app, farmer app)

This PR adds a backend database schema to store these app deployments, and frontend UI to select from the dashboard and view a list of all deployments on the server level.

There is still quite a lot of work to go to implement a full deployment system, this PR is more just to lay some ground work. Next updates should include:

**Additional changes**
Update how storgage objects are referenced and displayed, tracking storage objects by their path names instead of uniquely generated ids. This should make it easier in the future to migrate or backup storage, as reference remain unchanged even if objects are deleted and then added back

**Next TODOs**
- [ ] Integrate new deployments system into app country select
- [ ] Add new deployments from UI
- [ ] Edit deployments
- [ ] Restrict data viewable to a specific deployment
- [ ] Restrict which users can access specific deployments

## Discussion
- With the current design there is no limitation on the number of deployments, or how they are used. For example it would be possible to have multiple extension-facing deployments within a single country if wanting to share different information with different groups (e.g. implementation-partner specific), just as it is possible to include global versions focused on specific user groups (e.g. funder demos). Would be good to check this satisfies requirements and whether there might be any additional considerations to take into account.

- Currently the deployments are groupd for display purposes as 'extension' , 'farmer' and 'other'. Are there any other audience groups we may want to consider (or better word for 'other')?

- I've added placeholders for future support for deployments that can only be accessed with a password, as well as deployments that would be hidden from view in the app. Again would be good to clarify if we have use-cases for these at this point in time and whether to continue development in that direction


## Preview

_Link to app preview if relevant_

## Screenshots / Videos

[PICSA Dashboard (1).webm](https://github.com/e-picsa/picsa-apps/assets/10515065/9b5d08c5-5195-420a-b37e-bef010bb1285)

