### PR TITLE
feat: optimise svg drawing

### DIFF
--- a/libs/shared/src/features/drawing/drawing.component.html
+++ b/libs/shared/src/features/drawing/drawing.component.html
@@ -13,11 +13,18 @@
         height="100%"
         (pointerdown)="handlePointerDown($event)"
         (pointermove)="handlePointerMove($event)"
+        (mouseup)="handlePointerUp()"
         (pointerup)="handlePointerUp()"
         style="touch-action: none"
       >
-        @if(segments){
-        <path [attr.d]="pathData()" id="path-1" />
+        <!-- Previously rendered segments -->
+        @for(segment of segments; track segment.id){
+        <path [attr.d]="segment.path()" id="path-1" />
+        }
+
+        <!-- Active segment -->
+        @if(activeSegment){
+        <path [attr.d]="activeSegment.path()" id="path-1" />
         }
       </svg>
     </div>


### PR DESCRIPTION
## Description

SVG drawing feels quite sluggish, particularly on mobile (stops rendering after a few lines). Performance optimisations to:

- Track list of previous segments separate to active segment to avoid re-calculation and re-rendering of segments already completed
- Add id property to segments
- Add tolerance parameter to ignore adding new points when user has not moved much (lots of events/duplicate points fired before user has had a chance to move hand)
- Fix issue where pointerup event not always detected

**TODO**

- [ ] fix storing final path for future render/edit
- [ ] further testing on mobile
- [ ] integrate into budget tool

## Discussion

_Feedback discussion points if relevant (should also tag as `Feedback Discussion`)_

## Preview

_Link to app preview if relevant_

## Screenshots / Videos

_Include at least 1-2 screenshots of videos if visual changes_
