### PR TITLE
fix: show station data when global deployment selected

### DIFF
--- a/apps/picsa-tools/climate-tool/src/app/services/climate-data.service.ts
+++ b/apps/picsa-tools/climate-tool/src/app/services/climate-data.service.ts
@@ -24,6 +24,8 @@ export class ClimateDataService {
     }
   });
 
+  private stationHashmap = computed(() => arrayToHashmap(this.stations(), 'id'));
+
   constructor(private configurationService: ConfigurationService) {
     this.stationDataCache = arrayToHashmap(DATA.HARDCODED_STATIONS, 'id');
   }
@@ -63,8 +65,12 @@ export class ClimateDataService {
   }
 
   private async loadStationSummaries(stationID: string) {
-    const { country_code } = this.configurationService.deploymentSettings();
-    return loadCSV<IStationData>(`assets/summaries/${country_code}/${stationID}.csv`, {
+    const station = this.stationHashmap()[stationID];
+    if (!station) {
+      return [];
+    }
+    const { countryCode, id } = station;
+    return loadCSV<IStationData>(`assets/summaries/${countryCode}/${id}.csv`, {
       download: true,
       dynamicTyping: true,
       header: true,


### PR DESCRIPTION
## Description

Fix issue where individual station data would not show when global deployment selected

## Discussion

_Feedback discussion points if relevant (should also tag as `Feedback Discussion`)_

## Preview

_Link to app preview if relevant_

## Screenshots / Videos

_Include at least 1-2 screenshots of videos if visual changes_
