### PR TITLE
fix: native player crashes additional

### DIFF
--- a/.yarn/patches/capacitor-video-player-npm-6.0.0-21971dba2f.patch
+++ b/.yarn/patches/capacitor-video-player-npm-6.0.0-21971dba2f.patch
@@ -1,8 +1,75 @@
 diff --git a/android/src/main/java/com/jeep/plugin/capacitor/capacitorvideoplayer/FullscreenExoPlayerFragment.java b/android/src/main/java/com/jeep/plugin/capacitor/capacitorvideoplayer/FullscreenExoPlayerFragment.java
-index 108b80258f67cc289263b5850dd3dc9785866230..7df3abb5bf9f0d213fa4cf8607a861820e4d59cb 100644
+index 108b80258f67cc289263b5850dd3dc9785866230..838fb2e3c15763a7f168919dd19d6117806423e3 100644
 --- a/android/src/main/java/com/jeep/plugin/capacitor/capacitorvideoplayer/FullscreenExoPlayerFragment.java
 +++ b/android/src/main/java/com/jeep/plugin/capacitor/capacitorvideoplayer/FullscreenExoPlayerFragment.java
-@@ -560,29 +560,30 @@ public class FullscreenExoPlayerFragment extends Fragment {
+@@ -18,6 +18,7 @@ import android.os.AsyncTask;
+ import android.os.Build;
+ import android.os.Bundle;
+ import android.os.Handler;
++import android.os.Looper;
+ import android.provider.MediaStore;
+ import android.support.v4.media.session.MediaSessionCompat;
+ import android.util.Log;
+@@ -195,6 +196,10 @@ public class FullscreenExoPlayerFragment extends Fragment {
+   private CastStateListener castStateListener = null;
+   private Boolean playerReady = false;
+ 
++  // Thread safety and lifecycle management
++  private boolean isFragmentDestroyed = false;
++  private Handler mainHandler;
++
+   /**
+    * Create Fragment View
+    * @param inflater
+@@ -205,6 +210,11 @@ public class FullscreenExoPlayerFragment extends Fragment {
+   public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+     context = container.getContext();
+     packageManager = context.getPackageManager();
++    
++    // Initialize thread safety components
++    mainHandler = new Handler(Looper.getMainLooper());
++    isFragmentDestroyed = false;
++    
+     view = inflater.inflate(R.layout.fragment_fs_exoplayer, container, false);
+     constLayout = view.findViewById(R.id.fsExoPlayer);
+     linearLayout = view.findViewById(R.id.linearLayout);
+@@ -406,13 +416,15 @@ public class FullscreenExoPlayerFragment extends Fragment {
+                 new View.OnKeyListener() {
+                   @Override
+                   public boolean onKey(View v, int keyCode, KeyEvent event) {
++                    
+                     if (event.getAction() == KeyEvent.ACTION_UP) {
+-                      long videoPosition = player.getCurrentPosition();
++                      
+                       Log.v(TAG, "$$$$ onKey " + keyCode + " $$$$");
+                       if (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_HOME) {
+                         Log.v(TAG, "$$$$ Going to backpress $$$$");
+                         backPressed();
+                       } else if (isTV) {
++                        long videoPosition = (player == null) ? 0 : player.getCurrentPosition();
+                         switch (keyCode) {
+                           case KeyEvent.KEYCODE_DPAD_RIGHT:
+                             fastForward(videoPosition, 1);
+@@ -521,6 +533,18 @@ public class FullscreenExoPlayerFragment extends Fragment {
+     return styledPlayerView.isControllerFullyVisible();
+   }
+ 
++  /**
++   * Check if player operations are safe to perform
++   */
++  private boolean isPlayerOperationSafe() {
++    return !isFragmentDestroyed && 
++           player != null && 
++           getActivity() != null && 
++           !getActivity().isFinishing() && 
++           !getActivity().isDestroyed() &&
++           isAdded();
++  }
++
+   /**
+    * Perform backPressed Action
+    */
+@@ -560,29 +584,30 @@ public class FullscreenExoPlayerFragment extends Fragment {
    }
  
    public void playerExit() {
@@ -49,7 +116,39 @@ index 108b80258f67cc289263b5850dd3dc9785866230..7df3abb5bf9f0d213fa4cf8607a86182
      }
    }
  
-@@ -710,28 +711,46 @@ public class FullscreenExoPlayerFragment extends Fragment {
+@@ -674,9 +699,29 @@ public class FullscreenExoPlayerFragment extends Fragment {
+    */
+   @Override
+   public void onDestroy() {
+-    super.onDestroy();
+-    if (chromecast) mRouter.removeCallback(mCallback);
++    isFragmentDestroyed = true;
++    
++    // Release player before calling super to ensure proper cleanup order
+     releasePlayer();
++    
++    // Clean up handler
++    if (mainHandler != null) {
++        mainHandler.removeCallbacksAndMessages(null);
++        mainHandler = null;
++    }
++    
++    if (chromecast) mRouter.removeCallback(mCallback);
++    
++    super.onDestroy();
++  }
++
++  /**
++   * Perform onDetach Action
++   */
++  @Override
++  public void onDetach() {
++    isFragmentDestroyed = true;
++    super.onDetach();
+   }
+ 
+   /**
+@@ -710,26 +755,70 @@ public class FullscreenExoPlayerFragment extends Fragment {
      }
    }
  
@@ -57,6 +156,11 @@ index 108b80258f67cc289263b5850dd3dc9785866230..7df3abb5bf9f0d213fa4cf8607a86182
 -   * Release the player
 -   */
    public void releasePlayer() {
++    if (isFragmentDestroyed) {
++        Log.w("VideoPlayer", "Fragment already destroyed, skipping player release");
++        return;
++    }
++    
      if (player != null) {
 -      playWhenReady = player.getPlayWhenReady();
 -      playbackPosition = player.getCurrentPosition();
@@ -74,6 +178,26 @@ index 108b80258f67cc289263b5850dd3dc9785866230..7df3abb5bf9f0d213fa4cf8607a86182
 -        castPlayer = null;
 -      }
 +        try {
++            // Run on main thread to avoid handler issues
++            if (mainHandler != null && Looper.myLooper() != Looper.getMainLooper()) {
++                mainHandler.post(() -> releasePlayerInternal());
++            } else {
++                releasePlayerInternal();
++            }
++        } catch (Exception e) {
++            Log.e("VideoPlayer", "Error releasing player", e);
++            // Force cleanup
++            player = null;
++            if (castPlayer != null) {
++                castPlayer = null;
++            }
++        }
++    }
++  }
++
++  private void releasePlayerInternal() {
++    if (player != null && !isFragmentDestroyed) {
++        try {
 +            playWhenReady = player.getPlayWhenReady();
 +            playbackPosition = player.getCurrentPosition();
 +            currentWindow = player.getCurrentWindowIndex();
@@ -88,17 +212,17 @@ index 108b80258f67cc289263b5850dd3dc9785866230..7df3abb5bf9f0d213fa4cf8607a86182
 +            
 +            player.setRepeatMode(Player.REPEAT_MODE_OFF);
 +            player.removeListener(listener);
++            player.stop(); // Add this line to properly stop the player
 +            player.release();
 +        } catch (Exception e) {
-+            Log.e("VideoPlayer", "Error releasing player", e);
++            Log.e("VideoPlayer", "Error in releasePlayerInternal", e);
 +        } finally {
 +            player = null;
 +        }
 +        
 +        showSystemUI();
 +        resetVariables();
-     }
--  }
++    }
 +    
 +    // Move chromecast handling outside the player null check
 +    // and add null check for castPlayer
@@ -110,42 +234,89 @@ index 108b80258f67cc289263b5850dd3dc9785866230..7df3abb5bf9f0d213fa4cf8607a86182
 +        } finally {
 +            castPlayer = null;
 +        }
-+    }
-+}
+     }
+   }
  
-   /**
-    * Perform onResume Action
-@@ -1063,13 +1082,25 @@ public class FullscreenExoPlayerFragment extends Fragment {
+@@ -1063,19 +1152,72 @@ public class FullscreenExoPlayerFragment extends Fragment {
     * Start the player
     */
    public void play() {
 -    PlaybackParameters param = new PlaybackParameters(videoRate);
 -    player.setPlaybackParameters(param);
-+    // Add null check for player
-+    if (player == null) {
-+        Log.w("VideoPlayer", "Player is null, cannot play");
++    if (isFragmentDestroyed || player == null) {
++        Log.w("VideoPlayer", "Cannot play - fragment destroyed or player null");
 +        return;
 +    }
 +    
 +    try {
-+        PlaybackParameters param = new PlaybackParameters(videoRate);
-+        player.setPlaybackParameters(param);
- 
-         /* If the user start the cast before the player is ready and playing, then the video will start
-           in the device and chromecast at the same time. This is to avoid that behaviour.*/
--    if (!isCastSession) player.setPlayWhenReady(true);
--  }
-+        if (!isCastSession) {
-+            player.setPlayWhenReady(true);
++        // Ensure we're on the main thread
++        if (Looper.myLooper() != Looper.getMainLooper()) {
++            if (mainHandler != null) {
++                mainHandler.post(() -> playInternal());
++            }
++            return;
 +        }
++        
++        playInternal();
 +    } catch (Exception e) {
 +        Log.e("VideoPlayer", "Error during play operation", e);
 +    }
-+}
++  }
+ 
+-        /* If the user start the cast before the player is ready and playing, then the video will start
+-          in the device and chromecast at the same time. This is to avoid that behaviour.*/
+-    if (!isCastSession) player.setPlayWhenReady(true);
++  private void playInternal() {
++    if (player != null && !isFragmentDestroyed) {
++        try {
++            PlaybackParameters param = new PlaybackParameters(videoRate);
++            player.setPlaybackParameters(param);
++
++            /* If the user start the cast before the player is ready and playing, then the video will start
++              in the device and chromecast at the same time. This is to avoid that behaviour.*/
++            if (!isCastSession) {
++                player.setPlayWhenReady(true);
++            }
++        } catch (Exception e) {
++            Log.e("VideoPlayer", "Error in playInternal", e);
++        }
++    }
+   }
  
    /**
     * Pause the player
-@@ -1091,6 +1122,9 @@ public class FullscreenExoPlayerFragment extends Fragment {
+    */
+   public void pause() {
+-    if (player != null) player.setPlayWhenReady(false);
++    if (!isPlayerOperationSafe()) {
++        return;
++    }
++    
++    try {
++        if (Looper.myLooper() != Looper.getMainLooper()) {
++            if (mainHandler != null) {
++                mainHandler.post(() -> pauseInternal());
++            }
++            return;
++        }
++        pauseInternal();
++    } catch (Exception e) {
++        Log.e("VideoPlayer", "Error pausing player", e);
++    }
++  }
++
++  private void pauseInternal() {
++    if (player != null && !isFragmentDestroyed) {
++        try {
++            player.setPlayWhenReady(false);
++        } catch (Exception e) {
++            Log.e("VideoPlayer", "Error in pauseInternal", e);
++        }
++    }
+   }
+ 
+   /**
+@@ -1091,6 +1233,9 @@ public class FullscreenExoPlayerFragment extends Fragment {
     * @return int in seconds
     */
    public int getCurrentTime() {
@@ -155,6 +326,37 @@ index 108b80258f67cc289263b5850dd3dc9785866230..7df3abb5bf9f0d213fa4cf8607a86182
      return player.getCurrentPosition() == UNKNOWN_TIME ? 0 : (int) (player.getCurrentPosition() / 1000);
    }
  
+@@ -1099,14 +1244,23 @@ public class FullscreenExoPlayerFragment extends Fragment {
+    * @param timeSecond int
+    */
+   public void setCurrentTime(int timeSecond) {
+-    if (isInPictureInPictureMode) {
+-      styledPlayerView.setUseController(false);
+-      linearLayout.setVisibility(View.INVISIBLE);
++    if (!isPlayerOperationSafe()) {
++        Log.w("VideoPlayer", "Cannot set current time - player operation not safe");
++        return;
++    }
++    
++    try {
++        if (isInPictureInPictureMode) {
++            styledPlayerView.setUseController(false);
++            linearLayout.setVisibility(View.INVISIBLE);
++        }
++        long seekPosition = player.getCurrentPosition() == UNKNOWN_TIME
++            ? 0
++            : Math.min(Math.max(0, timeSecond * 1000), player.getDuration());
++        player.seekTo(seekPosition);
++    } catch (Exception e) {
++        Log.e("VideoPlayer", "Error setting current time", e);
+     }
+-    long seekPosition = player.getCurrentPosition() == UNKNOWN_TIME
+-      ? 0
+-      : Math.min(Math.max(0, timeSecond * 1000), player.getDuration());
+-    player.seekTo(seekPosition);
+   }
+ 
+   /**
 diff --git a/package.json b/package.json
 index ed15a76966c4485e37f3ac4d94708135a307080a..627f2cfab33ea6e095386b73f7b2d6529b70745b 100644
 --- a/package.json

--- a/apps/picsa-apps/extension-app-native/android/app/build.gradle
+++ b/apps/picsa-apps/extension-app-native/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "io.picsa.extension"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 3054003
-        versionName "3.54.3"
+        versionCode 3054004
+        versionName "3.54.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/libs/shared/src/features/video-player/player/video-player.native.ts
+++ b/libs/shared/src/features/video-player/player/video-player.native.ts
@@ -1,5 +1,6 @@
 import { Component, effect, input } from '@angular/core';
 import { ScreenOrientation } from '@capacitor/screen-orientation';
+import { generateID } from '@picsa/shared/services/core/db/db.service';
 import { _wait } from '@picsa/utils';
 import { CapacitorVideoPlayer, CapacitorVideoPlayerPlugin, capVideoPlayerOptions } from 'capacitor-video-player';
 
@@ -49,15 +50,17 @@ export class VideoPlayerNativeComponent extends VideoPlayerBaseComponent {
   }
 
   public async play() {
-    this.playerId = `video-${Date.now()}`;
     // Stop playback from any other players
     try {
       // Ensure any previously playing videos have a chance to stop
       await this.videoPlayer.stopAllPlayers();
+      this.removeListeners();
       await _wait(200);
     } catch (error) {
       // Silent fail - player might already be destroyed
     }
+    // Create a new player id to fix issue where pausing, exiting, and playing same file breaks player
+    this.playerId = `videoPlayer_${generateID(5)}`;
 
     // play needs to initialise every time on native
     await this.initPlayer();
@@ -169,14 +172,14 @@ export class VideoPlayerNativeComponent extends VideoPlayerBaseComponent {
   }
 
   private async handlePlayerPause(currentTime: number, playerId: string) {
-    // console.log('[Video Player] pause', currentTime);
+    console.log('[Video Player] pause', currentTime);
     if (playerId === this.playerId) {
       this.updatePlaybackProgress(currentTime);
     }
   }
 
   private async handlePlayerEnded(currentTime: number, playerId: string) {
-    // console.log('[Video Player] ended', currentTime);
+    console.log('[Video Player] ended', currentTime);
     if (playerId === this.playerId) {
       this.updatePlaybackProgress(currentTime);
       this.removeListeners();
@@ -184,7 +187,7 @@ export class VideoPlayerNativeComponent extends VideoPlayerBaseComponent {
   }
 
   private async handlePlayerExit(currentTime: number, playerId: string) {
-    // console.log('[Video Player] exit', currentTime, playerId);
+    console.log('[Video Player] exit', currentTime, playerId);
     // HACK - player exit can get caught by multiple players (listeners do not seem to unregister correctly)
     // so include playerId
     if (playerId === this.playerId) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picsa-apps",
-  "version": "3.54.3",
+  "version": "3.54.4",
   "license": "See LICENSE",
   "scripts": {
     "ng": "nx",
@@ -35,9 +35,8 @@
   },
   "private": true,
   "notes": {
-    "resolutions": {
-      "leaflet-draw": "required by enketo-core, short hash not matched from repo package.json"
-    }
+    "leaflet-draw": "resolution required by enketo-core, short hash not matched from repo package.json",
+    "capacitor-video-player": "see notes from PR 398 before upgrading"
   },
   "resolutions": {
     "leaflet-draw": "github:enketo/Leaflet.draw#ff730785db7fcccbf2485ffcf4dffe1238a7c617"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10692,11 +10692,11 @@ __metadata:
 
 "capacitor-video-player@patch:capacitor-video-player@npm%3A6.0.0#~/.yarn/patches/capacitor-video-player-npm-6.0.0-21971dba2f.patch":
   version: 6.0.0
-  resolution: "capacitor-video-player@patch:capacitor-video-player@npm%3A6.0.0#~/.yarn/patches/capacitor-video-player-npm-6.0.0-21971dba2f.patch::version=6.0.0&hash=10b9d1"
+  resolution: "capacitor-video-player@patch:capacitor-video-player@npm%3A6.0.0#~/.yarn/patches/capacitor-video-player-npm-6.0.0-21971dba2f.patch::version=6.0.0&hash=228ec1"
   peerDependencies:
     "@capacitor/core": ^6.0.0
     hls.js: ^1.4.0
-  checksum: 10c0/1e8171ba97e005500b91105e5bb0dd1487d0504bfc504bb1a03747cdd6a00c3a10f7aa87ca63f1178efea136ad64efee2bbdbe73b4e1b8a6e5ab0e231f1688f3
+  checksum: 10c0/472d63defab8451d59eee82dd267b20a3a9b0ad76f31b5c23c8b2cfed1797ebf25bf050893d258c150271da1a7e81b94292d49189e69af15b2da26d7200aba20
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Follow-up from #397 to fix issues related to the way the capacitor-video-player fails to properly manage video player lifecycle in certain scenarios.

The code updates were generated mostly using claud 4.0 ai prompts, and so would require closer inspection and migration if planning to update capacitor-video-player dep in the future.

Functional testing should involve successively opening, pausing and closing videos, and checking for crashes or console warnings related to player and/or ui threads being available/disposed/null etc.

## Discussion

_Feedback discussion points if relevant (should also tag as `Feedback Discussion`)_

## Preview

_Link to app preview if relevant_

## Screenshots / Videos

_Include at least 1-2 screenshots of videos if visual changes_
