### PR TITLE
fix: android safe area

### DIFF
--- a/apps/picsa-apps/app-native/android/app/build.gradle
+++ b/apps/picsa-apps/app-native/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "io.picsa.extension"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 5004003
-        versionName "5.4.3"
+        versionCode 5004004
+        versionName "5.4.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/MainActivity.java
+++ b/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/MainActivity.java
@@ -13,6 +13,7 @@ import android.graphics.Color;
 public class MainActivity extends BridgeActivity {
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
+    registerPlugin(SafeAreaPlugin.class);
     SafeAreaPolyfill.enableEdgeToEdge(this);
 
     // Track how long app startup takes to adjust how long to keep splash screen displayed

--- a/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/MainActivity.java
+++ b/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/MainActivity.java
@@ -1,26 +1,23 @@
 package io.picsa.extension;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
 
 import com.getcapacitor.BridgeActivity;
 
 import androidx.annotation.Nullable;
-import androidx.core.view.WindowCompat;
-import android.graphics.Color;
 
 public class MainActivity extends BridgeActivity {
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
     registerPlugin(SafeAreaPlugin.class);
-    SafeAreaPolyfill.enableEdgeToEdge(this);
 
     // Track how long app startup takes to adjust how long to keep splash screen displayed
     long START_TIME = System.currentTimeMillis();
 
     super.onCreate(savedInstanceState);
 
+    SafeAreaPolyfill.enableEdgeToEdge(this);
     SafeAreaPolyfill.applyListener(this);
     final View content = findViewById(android.R.id.content);
 

--- a/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPlugin.java
+++ b/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPlugin.java
@@ -15,6 +15,14 @@ public class SafeAreaPlugin extends Plugin {
     public void getInsets(PluginCall call) {
         JSObject ret = new JSObject();
         try {
+            if (getActivity() == null || getActivity().getWindow() == null || getContext() == null) {
+                ret.put("top", 0);
+                ret.put("bottom", 0);
+                ret.put("left", 0);
+                ret.put("right", 0);
+                call.resolve(ret);
+                return;
+            }
             float density = getContext().getResources().getDisplayMetrics().density;
             android.view.View decorView = getActivity().getWindow().getDecorView();
             WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(decorView);

--- a/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPlugin.java
+++ b/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPlugin.java
@@ -33,9 +33,9 @@ public class SafeAreaPlugin extends Plugin {
             int right = 0;
             
             if (insets != null) {
-                androidx.core.graphics.Insets systemBarInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+                androidx.core.graphics.Insets systemBarInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
                 top = (int) (systemBarInsets.top / density);
-                bottom = (int) (systemBarInsets.bottom / density);
+                bottom = insets.isVisible(WindowInsetsCompat.Type.ime()) ? 0 : (int) (systemBarInsets.bottom / density);
                 left = (int) (systemBarInsets.left / density);
                 right = (int) (systemBarInsets.right / density);
             }

--- a/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPlugin.java
+++ b/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPlugin.java
@@ -13,44 +13,55 @@ public class SafeAreaPlugin extends Plugin {
 
     @PluginMethod
     public void getInsets(PluginCall call) {
-        JSObject ret = new JSObject();
-        try {
-            if (getActivity() == null || getActivity().getWindow() == null || getContext() == null) {
-                ret.put("top", 0);
-                ret.put("bottom", 0);
-                ret.put("left", 0);
-                ret.put("right", 0);
-                call.resolve(ret);
-                return;
-            }
-            float density = getContext().getResources().getDisplayMetrics().density;
-            android.view.View decorView = getActivity().getWindow().getDecorView();
-            WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(decorView);
-            
-            int top = 0;
-            int bottom = 0;
-            int left = 0;
-            int right = 0;
-            
-            if (insets != null) {
-                androidx.core.graphics.Insets systemBarInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
-                top = (int) (systemBarInsets.top / density);
-                bottom = insets.isVisible(WindowInsetsCompat.Type.ime()) ? 0 : (int) (systemBarInsets.bottom / density);
-                left = (int) (systemBarInsets.left / density);
-                right = (int) (systemBarInsets.right / density);
-            }
-            
-            ret.put("top", top);
-            ret.put("bottom", bottom);
-            ret.put("left", left);
-            ret.put("right", right);
-            call.resolve(ret);
-        } catch (Exception e) {
+        if (getActivity() == null) {
+            JSObject ret = new JSObject();
             ret.put("top", 0);
             ret.put("bottom", 0);
             ret.put("left", 0);
             ret.put("right", 0);
             call.resolve(ret);
+            return;
         }
+        getActivity().runOnUiThread(() -> {
+            JSObject ret = new JSObject();
+            try {
+                if (getActivity() == null || getActivity().getWindow() == null || getContext() == null) {
+                    ret.put("top", 0);
+                    ret.put("bottom", 0);
+                    ret.put("left", 0);
+                    ret.put("right", 0);
+                    call.resolve(ret);
+                    return;
+                }
+                float density = getContext().getResources().getDisplayMetrics().density;
+                android.view.View decorView = getActivity().getWindow().getDecorView();
+                WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(decorView);
+                
+                int top = 0;
+                int bottom = 0;
+                int left = 0;
+                int right = 0;
+                
+                if (insets != null) {
+                    androidx.core.graphics.Insets systemBarInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+                    top = (int) (systemBarInsets.top / density);
+                    bottom = insets.isVisible(WindowInsetsCompat.Type.ime()) ? 0 : (int) (systemBarInsets.bottom / density);
+                    left = (int) (systemBarInsets.left / density);
+                    right = (int) (systemBarInsets.right / density);
+                }
+                
+                ret.put("top", top);
+                ret.put("bottom", bottom);
+                ret.put("left", left);
+                ret.put("right", right);
+                call.resolve(ret);
+            } catch (Exception e) {
+                ret.put("top", 0);
+                ret.put("bottom", 0);
+                ret.put("left", 0);
+                ret.put("right", 0);
+                call.resolve(ret);
+            }
+        });
     }
 }

--- a/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPlugin.java
+++ b/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPlugin.java
@@ -1,0 +1,48 @@
+package io.picsa.extension;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+@CapacitorPlugin(name = "SafeArea")
+public class SafeAreaPlugin extends Plugin {
+
+    @PluginMethod
+    public void getInsets(PluginCall call) {
+        JSObject ret = new JSObject();
+        try {
+            float density = getContext().getResources().getDisplayMetrics().density;
+            android.view.View decorView = getActivity().getWindow().getDecorView();
+            WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(decorView);
+            
+            int top = 0;
+            int bottom = 0;
+            int left = 0;
+            int right = 0;
+            
+            if (insets != null) {
+                androidx.core.graphics.Insets systemBarInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+                top = (int) (systemBarInsets.top / density);
+                bottom = (int) (systemBarInsets.bottom / density);
+                left = (int) (systemBarInsets.left / density);
+                right = (int) (systemBarInsets.right / density);
+            }
+            
+            ret.put("top", top);
+            ret.put("bottom", bottom);
+            ret.put("left", left);
+            ret.put("right", right);
+            call.resolve(ret);
+        } catch (Exception e) {
+            ret.put("top", 0);
+            ret.put("bottom", 0);
+            ret.put("left", 0);
+            ret.put("right", 0);
+            call.resolve(ret);
+        }
+    }
+}

--- a/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPlugin.java
+++ b/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPlugin.java
@@ -13,7 +13,8 @@ public class SafeAreaPlugin extends Plugin {
 
     @PluginMethod
     public void getInsets(PluginCall call) {
-        if (getActivity() == null) {
+        android.app.Activity activity = getActivity();
+        if (activity == null) {
             JSObject ret = new JSObject();
             ret.put("top", 0);
             ret.put("bottom", 0);
@@ -22,10 +23,12 @@ public class SafeAreaPlugin extends Plugin {
             call.resolve(ret);
             return;
         }
-        getActivity().runOnUiThread(() -> {
+        activity.runOnUiThread(() -> {
             JSObject ret = new JSObject();
             try {
-                if (getActivity() == null || getActivity().getWindow() == null || getContext() == null) {
+                android.view.Window window = activity.getWindow();
+                android.content.Context context = getContext();
+                if (window == null || context == null) {
                     ret.put("top", 0);
                     ret.put("bottom", 0);
                     ret.put("left", 0);
@@ -33,8 +36,8 @@ public class SafeAreaPlugin extends Plugin {
                     call.resolve(ret);
                     return;
                 }
-                float density = getContext().getResources().getDisplayMetrics().density;
-                android.view.View decorView = getActivity().getWindow().getDecorView();
+                float density = context.getResources().getDisplayMetrics().density;
+                android.view.View decorView = window.getDecorView();
                 WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(decorView);
                 
                 int top = 0;

--- a/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPolyfill.java
+++ b/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPolyfill.java
@@ -50,10 +50,11 @@ public class SafeAreaPolyfill {
 
         ViewCompat.setOnApplyWindowInsetsListener(parentView != null ? parentView : webView, (v, insets) -> {
             float density = activity.getResources().getDisplayMetrics().density;
-            int top = (int) (insets.getInsets(WindowInsetsCompat.Type.systemBars()).top / density);
-            int bottom = (int) (insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom / density);
-            int left = (int) (insets.getInsets(WindowInsetsCompat.Type.systemBars()).left / density);
-            int right = (int) (insets.getInsets(WindowInsetsCompat.Type.systemBars()).right / density);
+            androidx.core.graphics.Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+            int top = (int) (systemBars.top / density);
+            int bottom = insets.isVisible(WindowInsetsCompat.Type.ime()) ? 0 : (int) (systemBars.bottom / density);
+            int left = (int) (systemBars.left / density);
+            int right = (int) (systemBars.right / density);
             
             // Force WebView and its parent view to occupy full screen bounds with zero padding/margins,
             // only setting them if they are not already zero to prevent redundant layout requests.
@@ -72,17 +73,16 @@ public class SafeAreaPolyfill {
             }
             
             String script = String.format(
+                java.util.Locale.US,
                 "document.documentElement.style.setProperty('--safe-area-inset-top', '%dpx');" +
                 "document.documentElement.style.setProperty('--safe-area-inset-bottom', '%dpx');" +
                 "document.documentElement.style.setProperty('--safe-area-inset-left', '%dpx');" +
                 "document.documentElement.style.setProperty('--safe-area-inset-right', '%dpx');",
                 top, bottom, left, right
             );
-            webView.post(() -> {
-                if (activity.getBridge() != null && activity.getBridge().getWebView() != null) {
-                    activity.getBridge().getWebView().evaluateJavascript(script, null);
-                }
-            });
+            if (activity.getBridge() != null && activity.getBridge().getWebView() != null) {
+                activity.getBridge().getWebView().evaluateJavascript(script, null);
+            }
             
             return WindowInsetsCompat.CONSUMED;
         });

--- a/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPolyfill.java
+++ b/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPolyfill.java
@@ -29,7 +29,6 @@ public class SafeAreaPolyfill {
         // This listener explicitly injects them for older Androids so the CSS fallback works universally.
         // NOTE: On Android 15+ with outdated WebViews (< v140), Capacitor will gracefully 
         // fall back to a letterboxed layout and inject 0px to prevent double padding.
-        if (Build.VERSION.SDK_INT >= 35) return; // 35 = VANILLA_ICE_CREAM
 
         ViewCompat.setOnApplyWindowInsetsListener(activity.getWindow().getDecorView(), (v, insets) -> {
             if (activity.getBridge() != null && activity.getBridge().getWebView() != null) {

--- a/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPolyfill.java
+++ b/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPolyfill.java
@@ -4,6 +4,7 @@ import android.graphics.Color;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 import com.getcapacitor.BridgeActivity;
 
 public class SafeAreaPolyfill {
@@ -17,6 +18,16 @@ public class SafeAreaPolyfill {
         WindowCompat.setDecorFitsSystemWindows(activity.getWindow(), false);
         activity.getWindow().setStatusBarColor(Color.TRANSPARENT);
         activity.getWindow().setNavigationBarColor(Color.TRANSPARENT);
+
+        // NOTE: We control the status/navigation bar icon styles natively here instead of using the
+        // Capacitor SystemBars plugin configuration. Doing this programmatically provides 100% native control, 
+        // bypasses plugin loading order bugs (which can override custom layouts), and ensures that status bar
+        // icons remain white (light) on our dark primary header background, regardless of device system theme.
+        WindowInsetsControllerCompat controller = WindowCompat.getInsetsController(activity.getWindow(), activity.getWindow().getDecorView());
+        if (controller != null) {
+            controller.setAppearanceLightStatusBars(false); // false = light icons for dark backgrounds
+            controller.setAppearanceLightNavigationBars(false);
+        }
     }
 
     /**
@@ -34,7 +45,8 @@ public class SafeAreaPolyfill {
         }
 
         android.view.View webView = activity.getBridge().getWebView();
-        android.view.View parentView = (android.view.View) webView.getParent();
+        android.view.ViewParent parent = webView.getParent();
+        android.view.View parentView = parent instanceof android.view.View ? (android.view.View) parent : null;
 
         ViewCompat.setOnApplyWindowInsetsListener(parentView != null ? parentView : webView, (v, insets) -> {
             float density = activity.getResources().getDisplayMetrics().density;
@@ -43,13 +55,20 @@ public class SafeAreaPolyfill {
             int left = (int) (insets.getInsets(WindowInsetsCompat.Type.systemBars()).left / density);
             int right = (int) (insets.getInsets(WindowInsetsCompat.Type.systemBars()).right / density);
             
-            // Force WebView and its parent view to occupy full screen bounds with zero padding/margins
-            webView.setPadding(0, 0, 0, 0);
-            v.setPadding(0, 0, 0, 0);
+            // Force WebView and its parent view to occupy full screen bounds with zero padding/margins,
+            // only setting them if they are not already zero to prevent redundant layout requests.
+            if (webView.getPaddingLeft() != 0 || webView.getPaddingTop() != 0 || webView.getPaddingRight() != 0 || webView.getPaddingBottom() != 0) {
+                webView.setPadding(0, 0, 0, 0);
+            }
+            if (v.getPaddingLeft() != 0 || v.getPaddingTop() != 0 || v.getPaddingRight() != 0 || v.getPaddingBottom() != 0) {
+                v.setPadding(0, 0, 0, 0);
+            }
             if (webView.getLayoutParams() instanceof android.view.ViewGroup.MarginLayoutParams) {
                 android.view.ViewGroup.MarginLayoutParams lp = (android.view.ViewGroup.MarginLayoutParams) webView.getLayoutParams();
-                lp.setMargins(0, 0, 0, 0);
-                webView.setLayoutParams(lp);
+                if (lp.leftMargin != 0 || lp.topMargin != 0 || lp.rightMargin != 0 || lp.bottomMargin != 0) {
+                    lp.setMargins(0, 0, 0, 0);
+                    webView.setLayoutParams(lp);
+                }
             }
             
             String script = String.format(

--- a/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPolyfill.java
+++ b/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPolyfill.java
@@ -1,7 +1,6 @@
 package io.picsa.extension;
 
 import android.graphics.Color;
-import android.os.Build;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
@@ -11,7 +10,7 @@ public class SafeAreaPolyfill {
 
     /**
      * Enforce true edge-to-edge layouts on all Android versions.
-     * - Android 15+: Natively enforced by OS.
+     * - Android 15+: Natively enforced by OS (requires postSplashScreenTheme to be unlocked).
      * - Android <= 14: explicitly draws the app behind the system bars to match modern behavior.
      */
     public static void enableEdgeToEdge(BridgeActivity activity) {
@@ -21,33 +20,52 @@ public class SafeAreaPolyfill {
     }
 
     /**
-     * Polyfill safe area insets for Android < 15 since Capacitor 8 omits them.
+     * Intercept system bar insets and inject CSS custom properties to allow custom layouts
+     * to pad themselves safely, while disabling Capacitor's default native parent padding.
      */
     public static void applyListener(BridgeActivity activity) {
-        // Capacitor 8 handles CSS safe areas natively on modern environments.
-        // However, on Android < 15, the SystemBars plugin does not inject --safe-area-inset-* variables.
-        // This listener explicitly injects them for older Androids so the CSS fallback works universally.
-        // NOTE: On Android 15+ with outdated WebViews (< v140), Capacitor will gracefully 
-        // fall back to a letterboxed layout and inject 0px to prevent double padding.
+        // We bind the window insets listener directly to the WebView's parent container
+        // to overwrite Capacitor's default SystemBars listener and return CONSUMED to
+        // stop Capacitor from enforcing native layout margins/padding on the WebView.
+        // This allows true full-screen overlay layouts, with safety variables supplied via CSS.
 
-        ViewCompat.setOnApplyWindowInsetsListener(activity.getWindow().getDecorView(), (v, insets) -> {
-            if (activity.getBridge() != null && activity.getBridge().getWebView() != null) {
-                float density = activity.getResources().getDisplayMetrics().density;
-                int top = (int) (insets.getInsets(WindowInsetsCompat.Type.systemBars()).top / density);
-                int bottom = (int) (insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom / density);
-                int left = (int) (insets.getInsets(WindowInsetsCompat.Type.systemBars()).left / density);
-                int right = (int) (insets.getInsets(WindowInsetsCompat.Type.systemBars()).right / density);
-                
-                String script = String.format(
-                    "document.documentElement.style.setProperty('--safe-area-inset-top', '%dpx');" +
-                    "document.documentElement.style.setProperty('--safe-area-inset-bottom', '%dpx');" +
-                    "document.documentElement.style.setProperty('--safe-area-inset-left', '%dpx');" +
-                    "document.documentElement.style.setProperty('--safe-area-inset-right', '%dpx');",
-                    top, bottom, left, right
-                );
-                activity.getBridge().getWebView().evaluateJavascript(script, null);
+        if (activity.getBridge() == null || activity.getBridge().getWebView() == null) {
+            return;
+        }
+
+        android.view.View webView = activity.getBridge().getWebView();
+        android.view.View parentView = (android.view.View) webView.getParent();
+
+        ViewCompat.setOnApplyWindowInsetsListener(parentView != null ? parentView : webView, (v, insets) -> {
+            float density = activity.getResources().getDisplayMetrics().density;
+            int top = (int) (insets.getInsets(WindowInsetsCompat.Type.systemBars()).top / density);
+            int bottom = (int) (insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom / density);
+            int left = (int) (insets.getInsets(WindowInsetsCompat.Type.systemBars()).left / density);
+            int right = (int) (insets.getInsets(WindowInsetsCompat.Type.systemBars()).right / density);
+            
+            // Force WebView and its parent view to occupy full screen bounds with zero padding/margins
+            webView.setPadding(0, 0, 0, 0);
+            v.setPadding(0, 0, 0, 0);
+            if (webView.getLayoutParams() instanceof android.view.ViewGroup.MarginLayoutParams) {
+                android.view.ViewGroup.MarginLayoutParams lp = (android.view.ViewGroup.MarginLayoutParams) webView.getLayoutParams();
+                lp.setMargins(0, 0, 0, 0);
+                webView.setLayoutParams(lp);
             }
-            return ViewCompat.onApplyWindowInsets(v, insets);
+            
+            String script = String.format(
+                "document.documentElement.style.setProperty('--safe-area-inset-top', '%dpx');" +
+                "document.documentElement.style.setProperty('--safe-area-inset-bottom', '%dpx');" +
+                "document.documentElement.style.setProperty('--safe-area-inset-left', '%dpx');" +
+                "document.documentElement.style.setProperty('--safe-area-inset-right', '%dpx');",
+                top, bottom, left, right
+            );
+            webView.post(() -> {
+                if (activity.getBridge() != null && activity.getBridge().getWebView() != null) {
+                    activity.getBridge().getWebView().evaluateJavascript(script, null);
+                }
+            });
+            
+            return WindowInsetsCompat.CONSUMED;
         });
     }
 }

--- a/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPolyfill.java
+++ b/apps/picsa-apps/app-native/android/app/src/main/java/io/picsa/extension/SafeAreaPolyfill.java
@@ -84,7 +84,7 @@ public class SafeAreaPolyfill {
                 activity.getBridge().getWebView().evaluateJavascript(script, null);
             }
             
-            return WindowInsetsCompat.CONSUMED;
+            return ViewCompat.onApplyWindowInsets(v, insets);
         });
     }
 }

--- a/apps/picsa-apps/app-native/android/app/src/main/res/layout/activity_main.xml
+++ b/apps/picsa-apps/app-native/android/app/src/main/res/layout/activity_main.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
     <WebView
+        android:id="@+id/webview"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</FrameLayout>

--- a/apps/picsa-apps/app-native/android/app/src/main/res/values/styles.xml
+++ b/apps/picsa-apps/app-native/android/app/src/main/res/values/styles.xml
@@ -17,6 +17,7 @@
 
   <!--  Theme used during splash -->
   <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
+    <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
     <!-- Android 12+ splash screen attributes -->
     <item name="windowSplashScreenBackground">@color/white</item>
 <!--    NOTE animated, needs padding... currently use default app icon -->

--- a/apps/picsa-apps/app-native/capacitor.config.ts
+++ b/apps/picsa-apps/app-native/capacitor.config.ts
@@ -38,7 +38,9 @@ const config: CapacitorConfig = {
       presentationOptions: ['alert'],
     },
     SystemBars: {
-      insetsHandling: 'css',
+      // Disable automatic inset padding to allow custom full-screen edge-to-edge
+      // layout (insets and padding are handled manually in SafeAreaPolyfill.java)
+      insetsHandling: 'disable',
       style: 'DARK',
     },
   },

--- a/apps/picsa-apps/app/src/app/app.component.ts
+++ b/apps/picsa-apps/app/src/app/app.component.ts
@@ -17,6 +17,7 @@ import { ErrorHandlerService } from '@picsa/shared/services/core/error-handler.s
 import { PerformanceService } from '@picsa/shared/services/core/performance.service';
 import { PicsaPushNotificationService } from '@picsa/shared/services/core/push-notifications.service';
 import { AppUpdateService } from '@picsa/shared/services/native/app-update';
+import { SafeAreaService } from '@picsa/shared/services/native/safe-area';
 import { _wait } from '@picsa/utils';
 
 import { AppLayoutComponent } from './components/layout';
@@ -37,6 +38,7 @@ export class AppComponent implements OnInit {
   private monitoringService = inject(MonitoringToolService);
   private migrationService = inject(PicsaMigrationService);
   private appUpdateService = inject(AppUpdateService);
+  private safeAreaService = inject(SafeAreaService);
   private pushNotificationService = inject(PicsaPushNotificationService);
   private injector = inject(Injector);
   private appUserService = inject(AppUserService);
@@ -55,6 +57,8 @@ export class AppComponent implements OnInit {
         this.translateService.setLanguage(language_code);
       }
     });
+
+    this.safeAreaService.initialize();
   }
 
   async ngOnInit() {

--- a/libs/shared/src/services/native/index.ts
+++ b/libs/shared/src/services/native/index.ts
@@ -2,4 +2,5 @@
 
 export * from './app-update';
 export * from './print';
+export * from './safe-area';
 export * from './storage-service';

--- a/libs/shared/src/services/native/safe-area.ts
+++ b/libs/shared/src/services/native/safe-area.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core';
+import { Capacitor, registerPlugin } from '@capacitor/core';
+
+export interface SafeAreaInsets {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+export interface SafeAreaPlugin {
+  getInsets(): Promise<SafeAreaInsets>;
+}
+
+// Safely register plugin only if on a native platform
+const SafeArea = Capacitor.isNativePlatform() ? registerPlugin<SafeAreaPlugin>('SafeArea') : null;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SafeAreaService {
+  /**
+   * Retrieves the native safe area insets (status bar and navigation bar heights).
+   * Gracefully returns zero insets if not running on a native device.
+   */
+  async getInsets(): Promise<SafeAreaInsets> {
+    if (!Capacitor.isNativePlatform() || !SafeArea) {
+      return { top: 0, bottom: 0, left: 0, right: 0 };
+    }
+    try {
+      return await SafeArea.getInsets();
+    } catch (error) {
+      console.error('Error getting safe area insets:', error);
+      return { top: 0, bottom: 0, left: 0, right: 0 };
+    }
+  }
+
+  /**
+   * Initializes safe area variables and applies them to the document element style.
+   * Gracefully does nothing if not running on a native platform.
+   */
+  async initialize(): Promise<void> {
+    if (!Capacitor.isNativePlatform()) {
+      return;
+    }
+    try {
+      const insets = await this.getInsets();
+      document.documentElement.style.setProperty('--safe-area-inset-top', `${insets.top}px`);
+      document.documentElement.style.setProperty('--safe-area-inset-bottom', `${insets.bottom}px`);
+      document.documentElement.style.setProperty('--safe-area-inset-left', `${insets.left}px`);
+      document.documentElement.style.setProperty('--safe-area-inset-right', `${insets.right}px`);
+    } catch (error) {
+      console.error('Failed to apply safe area insets on startup:', error);
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picsa-apps",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "license": "See LICENSE",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Description

- improve handling of edge-to-edge layout for tablet devices
- replace system-bars plugin for custom code to better handle identified edge-cases

**Example - device with pinhole camera still applies relevant padding to ensure menu fully accessible**

<img width="630" height="945" alt="image" src="https://github.com/user-attachments/assets/1e7bdab0-b745-4b83-93d4-04f7ab6e5a3c" />

