### PR TITLE
Fix/forecast race condition

### DIFF
--- a/.agent/AI_GENERATED_KNOWLEDGE.md
+++ b/.agent/AI_GENERATED_KNOWLEDGE.md
@@ -139,3 +139,12 @@ This file is a shared knowledge base for AI agents operating on this codebase.
 **Date**: 2026-04-24
 **Context**: Refactoring components to standalone and importing the translate pipe.
 **Learning**: Never import `TranslatePipe` directly from `@ngx-translate/core`. The correct pattern for this project is to import `PicsaTranslateModule` from `@picsa/i18n` and add it to the `imports` array of your standalone component.
+
+### Supabase and RxDB Async Initialization Race Conditions
+
+**Date**: 2026-06-09
+**Context**: Fixing race conditions and TypeError exceptions when querying `SupabaseService.db` before it was defined, or when the database was offline.
+**Learning**:
+1. **Ready Race Condition**: If a service inherits from `PicsaAsyncService`, `ready()` resolves immediately when `init()` resolves. In `SupabaseService`, the client and database property (`db`) were initialized in an Angular `effect()` inside the constructor reacting to `isAvailable` signal changes. Since effects run asynchronously in the next change detection/microtask cycle, `ready()` could resolve *before* the effect ran, leaving `db` undefined. The fix was to initialize clients synchronously inside `init()`.
+2. **Offline Mode & Null Checks**: When the Supabase server is offline (detected via health check ping), `isAvailable` is set to `false` and the client/database properties are not created. Consequently, all queries hitting `supabaseService.db` directly would throw a `TypeError`. Every database service interacting with Supabase (such as `AppUserService`, `PicsaDatabaseSyncService`, and `ForecastService`) must check `isAvailable()` before performing any operations on `supabaseService.db`.
+3. **Async Effects in Angular**: Avoid writing asynchronous effects like `effect(async () => { await this.ready(); ... })`. Because Angular tracks dependencies synchronously, any signal accessed after the first `await` is not tracked. It also allows multiple instances of the asynchronous payload to execute concurrently, leading to race conditions. Instead, trigger the initialization of the service in the constructor and react to `this.readySignal()` synchronously in the effect, delegating asynchronous work to methods using cancellation tokens/trackers.

--- a/apps/picsa-apps/app-native/android/app/build.gradle
+++ b/apps/picsa-apps/app-native/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "io.picsa.extension"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 5004004
-        versionName "5.4.4"
+        versionCode 5005000
+        versionName "5.5.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.html
+++ b/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.html
@@ -12,54 +12,70 @@
 
   <!-- Short Term (Weekly + Daily) -->
   <h2>{{'Short Term' | translate}}</h2>
-  <div class="flex flex-wrap items-center gap-4 w-full">
-    @if (loading()) {
-      <div class="mx-auto w-24 mt-4">
+  <div class="w-full">
+    @if (loading() && dailyForecasts().length === 0 && weeklyForecasts().length === 0) {
+      <div class="mx-auto w-24 mt-4 mb-2">
         <mat-progress-bar mode="query"></mat-progress-bar>
       </div>
-    } @else if (!countryCode()) {
-      <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
-        {{ 'Please select a location to view forecasts' | translate }}
-      </div>
-    } @else if (dailyForecasts().length === 0 && weeklyForecasts().length === 0) {
-      <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
-        {{ 'No short term forecasts found' | translate }}
-      </div>
+    } @else if (loading()) {
+      <mat-progress-bar mode="indeterminate" class="h-1 mb-2"></mat-progress-bar>
     } @else {
-      @for(forecast of weeklyForecasts(); track forecast.id){
-        <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
-      }
-      @for(forecast of dailyForecasts(); track forecast.id){
-        <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
-      }
+      <div class="h-1 mb-2"></div>
     }
+
+    <div class="flex flex-wrap items-center gap-4 w-full">
+      @if (!countryCode()) {
+        <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
+          {{ 'Please select a location to view forecasts' | translate }}
+        </div>
+      } @else if (dailyForecasts().length === 0 && weeklyForecasts().length === 0) {
+        <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
+          {{ 'No short term forecasts found' | translate }}
+        </div>
+      } @else {
+        @for(forecast of weeklyForecasts(); track forecast.id){
+          <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
+        }
+        @for(forecast of dailyForecasts(); track forecast.id){
+          <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
+        }
+      }
+    </div>
   </div>
 
   <!-- Seasonal Forecasts -->
   <h2>{{'Seasonal' | translate}}</h2>
-  <div class="mt-2 flex flex-wrap items-center gap-4 w-full">
-    @if (loading() || loadingDownscaled()) {
-      <div class="mx-auto w-24 mt-4">
+  <div class="w-full">
+    @if ((loading() || loadingDownscaled()) && downscaledForecasts().length === 0 && seasonalForecasts().length === 0) {
+      <div class="mx-auto w-24 mt-4 mb-2">
         <mat-progress-bar mode="query"></mat-progress-bar>
       </div>
-    } @else if (!countryCode()) {
-      <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
-        {{ 'Please select a location to view forecasts' | translate }}
-      </div>
-    } @else if (downscaledForecasts().length === 0 && seasonalForecasts().length === 0) {
-      <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
-        {{ 'No seasonal forecasts found' | translate }}
-      </div>
+    } @else if (loading() || loadingDownscaled()) {
+      <mat-progress-bar mode="indeterminate" class="h-1 mb-2"></mat-progress-bar>
     } @else {
-      <!-- Downscaled -->
-      @for(forecast of downscaledForecasts(); track forecast.id){
-        <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
-      }
-      <!-- National -->
-      @for(forecast of seasonalForecasts(); track forecast.id){
-        <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
-      }
+      <div class="h-1 mb-2"></div>
     }
+
+    <div class="mt-2 flex flex-wrap items-center gap-4 w-full">
+      @if (!countryCode()) {
+        <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
+          {{ 'Please select a location to view forecasts' | translate }}
+        </div>
+      } @else if (downscaledForecasts().length === 0 && seasonalForecasts().length === 0) {
+        <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
+          {{ 'No seasonal forecasts found' | translate }}
+        </div>
+      } @else {
+        <!-- Downscaled -->
+        @for(forecast of downscaledForecasts(); track forecast.id){
+          <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
+        }
+        <!-- National -->
+        @for(forecast of seasonalForecasts(); track forecast.id){
+          <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
+        }
+      }
+    </div>
   </div>
 
   <!-- Resources -->

--- a/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.html
+++ b/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.html
@@ -12,30 +12,53 @@
 
   <!-- Short Term (Weekly + Daily) -->
   <h2>{{'Short Term' | translate}}</h2>
-  <div class="flex flex-wrap items-center gap-4">
-    @if(dailyForecasts().length===0 && weeklyForecasts().length===0){
-    <div class="mx-auto w-24 mt-4">
-      <mat-progress-bar mode="query"></mat-progress-bar>
-    </div>
-    } @for(forecast of weeklyForecasts(); track forecast.id){
-    <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
-    } @for(forecast of dailyForecasts(); track forecast.id){
-    <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
+  <div class="flex flex-wrap items-center gap-4 w-full">
+    @if (loading()) {
+      <div class="mx-auto w-24 mt-4">
+        <mat-progress-bar mode="query"></mat-progress-bar>
+      </div>
+    } @else if (!countryCode()) {
+      <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
+        {{ 'Please select a location to view forecasts' | translate }}
+      </div>
+    } @else if (dailyForecasts().length === 0 && weeklyForecasts().length === 0) {
+      <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
+        {{ 'No short term forecasts found' | translate }}
+      </div>
+    } @else {
+      @for(forecast of weeklyForecasts(); track forecast.id){
+        <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
+      }
+      @for(forecast of dailyForecasts(); track forecast.id){
+        <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
+      }
     }
   </div>
 
-  <!-- <div class="h-0 w-full"></div> -->
-
   <!-- Seasonal Forecasts -->
   <h2>{{'Seasonal' | translate}}</h2>
-  <div class="mt-2 flex flex-wrap items-center gap-4">
-    <!-- Downscaled -->
-    @for(forecast of downscaledForecasts(); track forecast.id){
-    <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
-    }
-    <!-- National -->
-    @for(forecast of seasonalForecasts(); track forecast.id){
-    <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
+  <div class="mt-2 flex flex-wrap items-center gap-4 w-full">
+    @if (loading() || loadingDownscaled()) {
+      <div class="mx-auto w-24 mt-4">
+        <mat-progress-bar mode="query"></mat-progress-bar>
+      </div>
+    } @else if (!countryCode()) {
+      <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
+        {{ 'Please select a location to view forecasts' | translate }}
+      </div>
+    } @else if (downscaledForecasts().length === 0 && seasonalForecasts().length === 0) {
+      <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
+        {{ 'No seasonal forecasts found' | translate }}
+      </div>
+    } @else {
+      <!-- Downscaled -->
+      @for(forecast of downscaledForecasts(); track forecast.id){
+        <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
+      }
+      <!-- National -->
+      @for(forecast of seasonalForecasts(); track forecast.id){
+        <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
+      }
     }
   </div>
 

--- a/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.ts
+++ b/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.ts
@@ -1,5 +1,14 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, effect, inject, OnDestroy, signal, viewChildren } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  OnDestroy,
+  signal,
+  viewChildren,
+} from '@angular/core';
 import { MatIcon } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { marker as translateMarker } from '@biesbjerg/ngx-translate-extract-marker';
@@ -35,6 +44,7 @@ interface IForecastSummary {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './forecast.page.html',
   styleUrls: ['./forecast.page.scss'],
   imports: [
@@ -72,16 +82,12 @@ export class ForecastComponent implements OnDestroy {
   // Utility to add type-safety to implicit ng-template data
   public toForecastType = (data: any) => data as IForecastSummary;
 
-  public FORECAST_HEADINGS = {};
-
   /** List of rendered SupabaseStorageDownload components for direct interaction */
   private downloaders = viewChildren(SupabaseStorageDownloadComponent);
 
   constructor() {
-    const configurationService = this.configurationService;
-
     effect(() => {
-      const { location } = configurationService.userSettings();
+      const { location } = this.configurationService.userSettings();
       this.service.setForecastLocation(location);
     });
   }

--- a/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.ts
+++ b/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.ts
@@ -74,6 +74,9 @@ export class ForecastComponent implements OnDestroy {
   public downscaledForecasts = computed(() => this.generateForecastSummary(this.service.downscaledForecastDocs()));
   public seasonalForecasts = computed(() => this.generateForecastSummary(this.service.seasonalForecastDocs()));
 
+  public loading = computed(() => this.service.loadingForecasts());
+  public loadingDownscaled = computed(() => this.service.loadingDownscaled());
+
   public resourceLinks = computed<IResourceLink[]>(() => {
     const { country_code } = this.configurationService.userSettings();
     return CLIMATE_RESOURCES[country_code] || [];

--- a/apps/picsa-tools/forecasts-tool/src/app/services/forecast.service.ts
+++ b/apps/picsa-tools/forecasts-tool/src/app/services/forecast.service.ts
@@ -43,6 +43,9 @@ export class ForecastService extends PicsaAsyncService {
   private downscaledLocation = signal<IDownscaledLocation>({}, { equal: isEqual });
   private countryLocation = signal<ICountryCode | undefined>(undefined);
 
+  private activeCountryLoad?: { country_code: ICountryCode; cancelled: boolean };
+  private activeDownscaledLoad?: { locationKey: string; cancelled: boolean };
+
   private loaderConfigs: LoaderConfig[] = [
     // TODO - limit not very useful, can have multiple translated versions
     //        Should try move to time-based filter/query instead, or better table replication
@@ -52,36 +55,50 @@ export class ForecastService extends PicsaAsyncService {
     { type: 'daily', signal: this.dailyForecastDocs, limit: 3, includeStorage: true },
   ];
 
-  private get table() {
-    return this.supabaseService.db.table('forecasts');
-  }
-
   private get dbCollection() {
     return this.dbService.db.collections['forecasts'] as RxCollection<IForecast>;
   }
 
   constructor() {
     super();
-    effect(async () => {
+    // Start initialization asynchronously on creation
+    this.ready();
+
+    effect(() => {
+      const isReady = this.readySignal();
+      if (!isReady) return;
+
       const country_code = this.countryLocation();
       if (country_code) {
-        await this.ready();
-        await this.loadAllForecastTypes(country_code);
+        this.loadForecastsForCountry(country_code);
+      } else {
+        if (this.activeCountryLoad) {
+          this.activeCountryLoad.cancelled = true;
+        }
+        this.seasonalForecastDocs.set([]);
+        this.weeklyForecastDocs.set([]);
+        this.dailyForecastDocs.set([]);
       }
     });
 
-    effect(async () => {
+    effect(() => {
+      const isReady = this.readySignal();
+      if (!isReady) return;
+
       const { country_code, admin_4, admin_5 } = this.downscaledLocation();
       if (country_code && admin_4) {
-        await this.ready();
         this.loadDownscaledForecasts(country_code, admin_4, admin_5);
       } else {
+        if (this.activeDownscaledLoad) {
+          this.activeDownscaledLoad.cancelled = true;
+        }
         this.downscaledForecastDocs.set([]);
       }
     });
   }
 
   public override async init(...args: any): Promise<void> {
+    await this.supabaseService.ready();
     await this.dbService.ensureCollections({
       forecasts: FORECAST_COLLECTION,
     });
@@ -120,28 +137,48 @@ export class ForecastService extends PicsaAsyncService {
     return doc;
   }
 
-  private async loadAllForecastTypes(country_code: ICountryCode) {
-    return Promise.all(this.loaderConfigs.map(async (config) => await this.loadForecastType(country_code, config)));
-  }
-
-  private async loadForecastType(country_code: ICountryCode, config: LoaderConfig) {
-    if (config.type === 'seasonal') {
-      return this.loadSeasonalForecasts(country_code);
+  private async loadForecastsForCountry(country_code: ICountryCode) {
+    if (this.activeCountryLoad) {
+      this.activeCountryLoad.cancelled = true;
     }
+    const currentLoad = { country_code, cancelled: false };
+    this.activeCountryLoad = currentLoad;
 
-    const cached = await this.loadCachedForecasts(country_code, config.type, config.limit || 1);
-    config.signal.set(cached);
+    try {
+      await Promise.all(
+        this.loaderConfigs.map(async (config) => {
+          if (config.type === 'seasonal') {
+            const seasonalForecasts = FORECASTS_DB.filter(
+              (v) => v.country_code === country_code && v.forecast_type === 'seasonal',
+            );
+            const dbDocs = await this.storeHardcodedData(seasonalForecasts);
+            if (currentLoad.cancelled) return;
+            config.signal.set(dbDocs);
+            return;
+          }
 
-    if (config.includeStorage) {
-      const serverForecasts = await this.loadServerForecasts(country_code, config.type, cached[0], config.limit);
-      if (serverForecasts.length > 0) {
-        const { success, error } = await this.saveForecasts(serverForecasts);
-        if (error.length > 0) {
-          console.error(error);
-          throw new Error(`[Forecast] failed to load ${config.type} forecasts`);
-        }
-        config.signal.update((v) => [...success, ...v].slice(0, config.limit));
-      }
+          const cached = await this.loadCachedForecasts(country_code, config.type, config.limit || 1);
+          if (currentLoad.cancelled) return;
+          config.signal.set(cached);
+
+          if (config.includeStorage) {
+            const serverForecasts = await this.loadServerForecasts(country_code, config.type, cached[0], config.limit);
+            if (currentLoad.cancelled) return;
+
+            if (serverForecasts.length > 0) {
+              const { success, error } = await this.saveForecasts(serverForecasts);
+              if (currentLoad.cancelled) return;
+              if (error.length > 0) {
+                console.error(error);
+                throw new Error(`[Forecast] failed to load ${config.type} forecasts`);
+              }
+              config.signal.update((v) => [...success, ...v].slice(0, config.limit));
+            }
+          }
+        }),
+      );
+    } catch (err) {
+      console.error('[ForecastService] Error loading forecasts', err);
     }
   }
 
@@ -152,11 +189,12 @@ export class ForecastService extends PicsaAsyncService {
     limit = 3,
   ): Promise<IForecast[]> {
     await this.supabaseService.ready();
-
-    const query = this.table
-      .select<'*', IForecastRow>('*')
-      .neq('storage_file', null)
-      .eq('forecast_type', forecast_type);
+    if (!this.supabaseService.isAvailable()) {
+      console.warn('[Forecast] Supabase server is not available, skipping loadServerForecasts');
+      return [];
+    }
+    const table = this.supabaseService.db.table('forecasts');
+    const query = table.select<'*', IForecastRow>('*').neq('storage_file', null).eq('forecast_type', forecast_type);
 
     if (country_code !== 'global') {
       query.eq('country_code', country_code);
@@ -185,15 +223,27 @@ export class ForecastService extends PicsaAsyncService {
   }
 
   private async loadDownscaledForecasts(country_code: string, admin_4: string, admin_5?: string) {
-    const filters: ((v: IForecastRow) => boolean)[] = [
-      (v) => v.forecast_type === 'downscaled',
-      (v) => v.country_code === country_code,
-      (v) => (admin_5 && v.downscaled_location === admin_5) || v.downscaled_location === admin_4,
-    ];
+    const locationKey = `${country_code}||${admin_4}||${admin_5 || ''}`;
+    if (this.activeDownscaledLoad) {
+      this.activeDownscaledLoad.cancelled = true;
+    }
+    const currentLoad = { locationKey, cancelled: false };
+    this.activeDownscaledLoad = currentLoad;
 
-    const forecasts = FORECASTS_DB.filter((v) => filters.every((fn) => fn(v)));
-    const dbDocs = await this.storeHardcodedData(forecasts);
-    this.downscaledForecastDocs.set(dbDocs);
+    try {
+      const filters: ((v: IForecastRow) => boolean)[] = [
+        (v) => v.forecast_type === 'downscaled',
+        (v) => v.country_code === country_code,
+        (v) => (admin_5 && v.downscaled_location === admin_5) || v.downscaled_location === admin_4,
+      ];
+
+      const forecasts = FORECASTS_DB.filter((v) => filters.every((fn) => fn(v)));
+      const dbDocs = await this.storeHardcodedData(forecasts);
+      if (currentLoad.cancelled) return;
+      this.downscaledForecastDocs.set(dbDocs);
+    } catch (err) {
+      console.error('[ForecastService] Error loading downscaled forecasts', err);
+    }
   }
 
   private async storeHardcodedData(forecasts: IForecastRow[] = []) {

--- a/apps/picsa-tools/forecasts-tool/src/app/services/forecast.service.ts
+++ b/apps/picsa-tools/forecasts-tool/src/app/services/forecast.service.ts
@@ -149,26 +149,40 @@ export class ForecastService extends PicsaAsyncService {
     const currentLoad = { country_code, cancelled: false };
     this.activeCountryLoad = currentLoad;
 
-    this.loadingForecasts.set(true);
+    // Filter out downscaled config from country load because it is loaded by the specific location effect
+    const countryConfigs = this.loaderConfigs.filter((c) => c.type !== 'downscaled');
 
     try {
-      await Promise.all(
-        this.loaderConfigs.map(async (config) => {
+      // 1. Load cached data first (extremely fast local queries)
+      const cachedData = await Promise.all(
+        countryConfigs.map(async (config) => {
           if (config.type === 'seasonal') {
             const seasonalForecasts = FORECASTS_DB.filter(
               (v) => v.country_code === country_code && v.forecast_type === 'seasonal',
             );
             const dbDocs = await this.storeHardcodedData(seasonalForecasts);
-            if (currentLoad.cancelled) return;
-            config.signal.set(dbDocs);
-            return;
+            return { config, data: dbDocs };
           }
-
           const cached = await this.loadCachedForecasts(country_code, config.type, config.limit || 1);
-          if (currentLoad.cancelled) return;
-          config.signal.set(cached);
+          return { config, data: cached };
+        }),
+      );
 
-          if (config.includeStorage) {
+      if (currentLoad.cancelled) return;
+
+      // 2. Set the cached data to signals immediately
+      for (const { config, data } of cachedData) {
+        config.signal.set(data);
+      }
+
+      // 3. Now start loading from server (which might take time)
+      const serverConfigs = countryConfigs.filter((c) => c.includeStorage);
+      if (serverConfigs.length > 0) {
+        this.loadingForecasts.set(true);
+
+        await Promise.all(
+          serverConfigs.map(async (config) => {
+            const cached = config.signal();
             const serverForecasts = await this.loadServerForecasts(country_code, config.type, cached[0], config.limit);
             if (currentLoad.cancelled) return;
 
@@ -181,9 +195,9 @@ export class ForecastService extends PicsaAsyncService {
               }
               config.signal.update((v) => [...success, ...v].slice(0, config.limit));
             }
-          }
-        }),
-      );
+          }),
+        );
+      }
     } catch (err) {
       console.error('[ForecastService] Error loading forecasts', err);
     } finally {

--- a/apps/picsa-tools/forecasts-tool/src/app/services/forecast.service.ts
+++ b/apps/picsa-tools/forecasts-tool/src/app/services/forecast.service.ts
@@ -193,7 +193,16 @@ export class ForecastService extends PicsaAsyncService {
                 console.error(error);
                 throw new Error(`[Forecast] failed to load ${config.type} forecasts`);
               }
-              config.signal.update((v) => [...success, ...v].slice(0, config.limit));
+              config.signal.update((v) => {
+                const seen = new Set<string>();
+                return [...success, ...v]
+                  .filter((doc) => {
+                    if (seen.has(doc.id)) return false;
+                    seen.add(doc.id);
+                    return true;
+                  })
+                  .slice(0, config.limit);
+              });
             }
           }),
         );

--- a/apps/picsa-tools/forecasts-tool/src/app/services/forecast.service.ts
+++ b/apps/picsa-tools/forecasts-tool/src/app/services/forecast.service.ts
@@ -46,6 +46,9 @@ export class ForecastService extends PicsaAsyncService {
   private activeCountryLoad?: { country_code: ICountryCode; cancelled: boolean };
   private activeDownscaledLoad?: { locationKey: string; cancelled: boolean };
 
+  public loadingForecasts = signal(false);
+  public loadingDownscaled = signal(false);
+
   private loaderConfigs: LoaderConfig[] = [
     // TODO - limit not very useful, can have multiple translated versions
     //        Should try move to time-based filter/query instead, or better table replication
@@ -78,6 +81,7 @@ export class ForecastService extends PicsaAsyncService {
         this.seasonalForecastDocs.set([]);
         this.weeklyForecastDocs.set([]);
         this.dailyForecastDocs.set([]);
+        this.loadingForecasts.set(false);
       }
     });
 
@@ -93,6 +97,7 @@ export class ForecastService extends PicsaAsyncService {
           this.activeDownscaledLoad.cancelled = true;
         }
         this.downscaledForecastDocs.set([]);
+        this.loadingDownscaled.set(false);
       }
     });
   }
@@ -144,6 +149,8 @@ export class ForecastService extends PicsaAsyncService {
     const currentLoad = { country_code, cancelled: false };
     this.activeCountryLoad = currentLoad;
 
+    this.loadingForecasts.set(true);
+
     try {
       await Promise.all(
         this.loaderConfigs.map(async (config) => {
@@ -179,6 +186,10 @@ export class ForecastService extends PicsaAsyncService {
       );
     } catch (err) {
       console.error('[ForecastService] Error loading forecasts', err);
+    } finally {
+      if (!currentLoad.cancelled) {
+        this.loadingForecasts.set(false);
+      }
     }
   }
 
@@ -230,6 +241,8 @@ export class ForecastService extends PicsaAsyncService {
     const currentLoad = { locationKey, cancelled: false };
     this.activeDownscaledLoad = currentLoad;
 
+    this.loadingDownscaled.set(true);
+
     try {
       const filters: ((v: IForecastRow) => boolean)[] = [
         (v) => v.forecast_type === 'downscaled',
@@ -243,6 +256,10 @@ export class ForecastService extends PicsaAsyncService {
       this.downscaledForecastDocs.set(dbDocs);
     } catch (err) {
       console.error('[ForecastService] Error loading downscaled forecasts', err);
+    } finally {
+      if (!currentLoad.cancelled) {
+        this.loadingDownscaled.set(false);
+      }
     }
   }
 

--- a/libs/shared/src/services/core/appUser.service.ts
+++ b/libs/shared/src/services/core/appUser.service.ts
@@ -1,4 +1,4 @@
-import { computed, effect, inject,Injectable, signal } from '@angular/core';
+import { computed, effect, inject, Injectable, signal } from '@angular/core';
 import { Capacitor } from '@capacitor/core';
 import { ConfigurationService } from '@picsa/configuration';
 import { APP_VERSION } from '@picsa/environments/src/version';
@@ -65,6 +65,7 @@ export class AppUserService {
     effect(async () => {
       if (!this.enabled()) return;
       await this.supabaseService.ready();
+      if (!this.supabaseService.isAvailable()) return;
       const isOnline = this.networkService.isOnline();
       const userId = this.userId();
       if (isOnline && !userId) {
@@ -75,6 +76,8 @@ export class AppUserService {
     // When user is online attempt to load profile from DB (create if does not exist)
     effect(async () => {
       if (!this.enabled()) return;
+      await this.supabaseService.ready();
+      if (!this.supabaseService.isAvailable()) return;
       const userId = this.userId();
       const isOnline = this.networkService.isOnline();
       if (isOnline && userId && !this.dbProfile()) {
@@ -90,6 +93,8 @@ export class AppUserService {
     // When user is online attempt sync pending update
     effect(async () => {
       if (!this.enabled()) return;
+      await this.supabaseService.ready();
+      if (!this.supabaseService.isAvailable()) return;
       const userId = this.userId();
       const isOnline = this.networkService.isOnline();
       const pendingUpdate = this.pendingDBUpdateDebounded();
@@ -100,6 +105,7 @@ export class AppUserService {
   }
 
   private async loadDbUserProfile(user_id: string) {
+    if (!this.supabaseService.isAvailable()) return null;
     const { data, error } = await this.table.select('*').eq('user_id', user_id).maybeSingle();
     if (error) {
       this.errorService.handleError(error);
@@ -108,6 +114,7 @@ export class AppUserService {
   }
 
   private async createUserProfile(user_id: string) {
+    if (!this.supabaseService.isAvailable()) return;
     const userProfile = this.userProfile();
     const { data, error } = await this.table
       .insert({ ...userProfile, user_id })
@@ -123,6 +130,7 @@ export class AppUserService {
   }
 
   private async updateUserProfile(user_id: string) {
+    if (!this.supabaseService.isAvailable()) return;
     const userProfile = this.userProfile();
     const dbProfile = this.dbProfile();
 

--- a/libs/shared/src/services/core/db_v2/db-sync.service.ts
+++ b/libs/shared/src/services/core/db_v2/db-sync.service.ts
@@ -1,4 +1,4 @@
-import { inject,Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Network } from '@capacitor/network';
 import { _wait } from '@picsa/utils';
 import { RxCollection, RxDatabase, RxDocument } from 'rxdb';
@@ -124,6 +124,9 @@ export class PicsaDatabaseSyncService {
 
   private async pushDeletionsToSupabase() {
     await this.supabaseService.ready();
+    if (!this.supabaseService.isAvailable()) {
+      return;
+    }
     const pendingDeleteDocs = await this.syncDeleteCollection.find().exec();
     const ops = pendingDeleteDocs.map(async (doc) => {
       const { collectionName, documentId } = doc._data;
@@ -141,6 +144,9 @@ export class PicsaDatabaseSyncService {
 
   private async pushDocsToSupabase(docs: RxDocument<ISyncPushEntry>[], collection: RxCollection) {
     await this.supabaseService.ready();
+    if (!this.supabaseService.isAvailable()) {
+      return { status: 503, error: { message: 'Supabase server not available' } } as any;
+    }
     const records = docs.map((d) => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { _meta, _rev, _sync_push_status, _sync_push_timestamp, ...keptFields } = d._data as ISyncPushEntry;

--- a/libs/shared/src/services/core/supabase/supabase.service.ts
+++ b/libs/shared/src/services/core/supabase/supabase.service.ts
@@ -39,21 +39,13 @@ export class SupabaseService extends PicsaAsyncService {
 
   private supabase: SupabaseClient<Database>;
 
-  constructor() {
-    super();
-    effect(() => {
-      const isAvailable = this.isAvailable();
-      if (isAvailable && !this.supabase) {
-        this.createClients();
-      }
-    });
-  }
-
   public override async init(): Promise<void> {
     this.config = await this.loadConfig();
     const isServerAvailable = await checkBackendAvailability(this.config.apiUrl);
     this.isAvailable.set(isServerAvailable);
-    // client config will be handled by effect
+    if (isServerAvailable) {
+      this.createClients();
+    }
   }
 
   private createClients() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picsa-apps",
-  "version": "5.4.4",
+  "version": "5.5.0",
   "license": "See LICENSE",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Description

- improve logic when loading forecasts to avoid race condition where forecasts would attempt load before db ready
- improve loading state to distinguish between forecasts loading and no forecasts available

**Example - Forecasts now clearly specify if none available on server**
<img width="400" alt="localhost_4200_forecasts(Nexus 6P)" src="https://github.com/user-attachments/assets/172bceab-9509-417c-a249-80a9cfb77b09" />
