### PR TITLE
feat: country-specific climate translations

### DIFF
--- a/apps/picsa-apps/dashboard/jest.config.ts
+++ b/apps/picsa-apps/dashboard/jest.config.ts
@@ -13,7 +13,7 @@ export default {
       },
     ],
   },
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$|ky|@uppy|nanoid|p-queue|p-timeout)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/apps/picsa-apps/dashboard/src/app/modules/translations/pages/import/components/json-import/json-import.component.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/translations/pages/import/components/json-import/json-import.component.ts
@@ -16,17 +16,21 @@ import { arrayToHashmap } from '@picsa/utils';
 import Uppy from '@uppy/core';
 import DragDrop from '@uppy/drag-drop';
 
-import { TranslationDashboardService } from '../../../../translations.service';
+import { ITranslationInsert, TranslationDashboardService } from '../../../../translations.service';
 
 type ITranslationRow = Database['public']['Tables']['translations']['Row'];
 
 interface ITranslationFileEntry {
+  /** custom id if specified */
+  id?: string;
   /** case-sensitive string representation for translation */
   text: string;
   /** associated tool for context */
   tool: string;
   /** additional context related to tool */
   context?: string;
+  /** country code if specified */
+  country_code?: string | null;
 }
 
 interface ITranslationImportEntry extends ITranslationFileEntry {
@@ -102,7 +106,7 @@ export class TranslationsJSONImportComponent {
       this.importCounter.update((v) => v + 1);
     }
     for (const entry of add) {
-      await this.service.addTranslation(entry);
+      await this.service.addTranslation(entry as ITranslationInsert);
       this.importCounter.update((v) => v + 1);
     }
   }
@@ -137,7 +141,7 @@ export class TranslationsJSONImportComponent {
     }
     const localHashmap: Record<string, ITranslationFileEntry> = {};
     for (const entry of entries) {
-      const id = this.service.generateTranslationID(entry as ITranslationRow);
+      const id = entry.id || this.service.generateTranslationID(entry as ITranslationRow);
       localHashmap[id] = entry;
     }
     await this.service.ready();
@@ -172,12 +176,12 @@ export class TranslationsJSONImportComponent {
     for (const [id, entry] of Object.entries(server)) {
       const localEntry = local[id];
       if (!localEntry) {
-        const { tool, context, text, archived } = entry;
+        const { tool, context, text, archived, country_code } = entry;
         if (!archived) {
-          summary.archive.push({ id, tool, text, context: context || undefined });
+          summary.archive.push({ id, tool, text, context: context || undefined, country_code });
         } else {
           // Already archived, so no action required
-          summary.skip.push({ id, tool, text, context: context || undefined });
+          summary.skip.push({ id, tool, text, context: context || undefined, country_code });
         }
       }
     }

--- a/apps/picsa-apps/dashboard/src/app/modules/translations/translations.service.spec.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/translations/translations.service.spec.ts
@@ -1,0 +1,112 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { SupabaseService } from '@picsa/shared/services/core/supabase';
+
+import { DeploymentDashboardService } from '../deployment/deployment.service';
+import { TranslationDashboardService } from './translations.service';
+
+describe('TranslationDashboardService', () => {
+  let service: TranslationDashboardService;
+  let mockSupabase: any;
+  let mockDeployment: any;
+
+  beforeEach(() => {
+    mockSupabase = {
+      ready: () => Promise.resolve(),
+      db: {
+        table: (tableName: string) => {
+          return {
+            select: () => {
+              const query: any = {
+                or: (filterStr: string) => {
+                  mockSupabase.lastFilter = filterStr;
+                  return Promise.resolve({ data: mockSupabase.mockData, error: null });
+                },
+                then: (resolve: any) => {
+                  mockSupabase.lastFilter = '';
+                  return Promise.resolve({ data: mockSupabase.mockData, error: null }).then(resolve);
+                },
+              };
+              return query;
+            },
+            insert: (data: any[]) => {
+              mockSupabase.lastInsert = data;
+              return Promise.resolve({ data, error: null });
+            },
+          };
+        },
+      },
+      lastFilter: '',
+      lastInsert: null as any,
+      mockData: [] as any[],
+    };
+
+    mockDeployment = {
+      activeDeployment: signal<any>(null),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        TranslationDashboardService,
+        { provide: SupabaseService, useValue: mockSupabase },
+        { provide: DeploymentDashboardService, useValue: mockDeployment },
+      ],
+    });
+
+    service = TestBed.inject(TranslationDashboardService);
+  });
+
+  it('should generate translation ID if not present', async () => {
+    const entry = {
+      tool: 'budget',
+      context: 'inputs',
+      text: 'Vaccine',
+    };
+    await service.addTranslation(entry as any);
+    expect(mockSupabase.lastInsert[0].id).toBe('budget-inputs-vaccine');
+  });
+
+  it('should preserve custom translation ID if present', async () => {
+    const entry = {
+      id: 'custom:id:for:vaccine',
+      tool: 'budget',
+      context: 'inputs',
+      text: 'Vaccine',
+    };
+    await service.addTranslation(entry as any);
+    expect(mockSupabase.lastInsert[0].id).toBe('custom:id:for:vaccine');
+  });
+
+  it('should filter by active deployment country code', async () => {
+    mockDeployment.activeDeployment.set({ country_code: 'mw' });
+    mockSupabase.mockData = [
+      { id: 'global-1', tool: 'climate', text: 'Global text', country_code: null },
+      { id: 'mw:climate.chart.1', tool: 'climate', text: 'Malawi override', country_code: 'mw' },
+    ];
+
+    await service.listTranslations();
+    expect(mockSupabase.lastFilter).toContain('country_code.eq.mw');
+    expect(mockSupabase.lastFilter).toContain('country_code.is.null');
+    expect(service.translations().length).toBe(2);
+  });
+
+  it('should export correct JSON structure with standard and custom keys', () => {
+    service.translations.set([
+      { id: 'budget-inputs-vaccine', tool: 'budget', context: 'inputs', text: 'Vaccine', mw_ny: 'Katambala' },
+      {
+        id: 'mw:climate.chart.end.definition',
+        tool: 'climate',
+        context: 'chart',
+        text: 'End definition',
+        mw_ny: 'Tanthauzo lomaliza',
+      },
+    ] as any[]);
+
+    const json = service.exportJson('mw_ny');
+    // Standard translation key should be the English text
+    expect(json['Vaccine']).toBe('Katambala');
+    // Custom ID translation should be present under its text AND its custom ID
+    expect(json['End definition']).toBe('Tanthauzo lomaliza');
+    expect(json['mw:climate.chart.end.definition']).toBe('Tanthauzo lomaliza');
+  });
+});

--- a/apps/picsa-apps/dashboard/src/app/modules/translations/translations.service.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/translations/translations.service.ts
@@ -132,7 +132,7 @@ export class TranslationDashboardService extends PicsaAsyncService {
   public exportJson(locale: string, shouldDownload = false) {
     const data = this.translations();
     const translations = new Map<string, string>();
-    const sortedData = data.sort((a, b) => (a.text.toLowerCase() > b.text.toLowerCase() ? 1 : -1));
+    const sortedData = [...data].sort((a, b) => (a.text.toLowerCase() > b.text.toLowerCase() ? 1 : -1));
 
     for (const row of sortedData) {
       const { text, id } = row;

--- a/apps/picsa-apps/dashboard/src/app/modules/translations/translations.service.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/translations/translations.service.ts
@@ -7,6 +7,8 @@ import { arrayToHashmap } from '@picsa/utils';
 import download from 'downloadjs';
 import JSZip from 'jszip';
 
+import { DeploymentDashboardService } from '../deployment/deployment.service';
+
 type ITranslationDB = Database['public']['Tables']['translations'];
 export type ITranslationRow = ITranslationDB['Row'];
 export type ITranslationInsert = ITranslationDB['Insert'];
@@ -14,6 +16,7 @@ export type ITranslationInsert = ITranslationDB['Insert'];
 @Injectable({ providedIn: 'root' })
 export class TranslationDashboardService extends PicsaAsyncService {
   private supabaseService = inject(SupabaseService);
+  private deploymentService = inject(DeploymentDashboardService);
 
   public translations = signal<ITranslationRow[]>([]);
 
@@ -30,13 +33,25 @@ export class TranslationDashboardService extends PicsaAsyncService {
   }
 
   public async listTranslations() {
-    const { data, error } = await this.supabaseService.db.table('translations').select<'*', ITranslationRow>('*');
+    const activeDeployment = this.deploymentService.activeDeployment();
+    const countryCode = activeDeployment?.country_code;
+
+    let query = this.supabaseService.db.table('translations').select<'*', ITranslationRow>('*');
+
+    if (countryCode && countryCode !== 'global') {
+      query = query.or(`country_code.eq.${countryCode},country_code.is.null,country_code.eq.global`);
+    } else {
+      query = query.or('country_code.is.null,country_code.eq.global');
+    }
+
+    const { data, error } = await query;
     if (error) {
       throw error;
     }
     this.translations.set(data || []);
     this.translationsHashmap = arrayToHashmap(data, 'id');
   }
+
   // update a translation record by ID
   public async updateTranslationById(id: string, updatedData: Partial<ITranslationRow>) {
     // Save to DB
@@ -85,7 +100,7 @@ export class TranslationDashboardService extends PicsaAsyncService {
 
   // In your TranslationDashboardService
   public async addTranslation(translation: ITranslationInsert): Promise<string> {
-    translation.id = this.generateTranslationID(translation);
+    translation.id = translation.id || this.generateTranslationID(translation);
     const { data, error } = await this.supabaseService.db.table('translations').insert([translation]);
 
     if (error) {
@@ -119,27 +134,25 @@ export class TranslationDashboardService extends PicsaAsyncService {
     const translations = new Map<string, string>();
     const sortedData = data.sort((a, b) => (a.text.toLowerCase() > b.text.toLowerCase() ? 1 : -1));
 
-    for (const { text, ...columns } of sortedData) {
-      const existingTranslation = translations.get(text);
-      if (!existingTranslation) {
-        // Add placeholder to track missing translations
-        translations.set(text, '');
-      }
+    for (const row of sortedData) {
+      const { text, id } = row;
+      const translatedText = row[locale];
 
-      // Store translated text
-      const translatedText = columns[locale];
-      if (translatedText !== null) {
-        if (existingTranslation && translatedText !== existingTranslation) {
-          console.warn('Duplicate translation skipped', { text, translatedText, existingTranslation });
-        } else {
-          translations.set(text, translatedText);
+      if (translatedText !== null && translatedText !== undefined && translatedText !== '') {
+        translations.set(text, translatedText);
+
+        const generatedId = this.generateTranslationID(row);
+        if (id && id !== generatedId) {
+          translations.set(id, translatedText);
         }
-      }
-    }
-    // Replace missing translations with marker fallback
-    for (const [key, value] of translations.entries()) {
-      if (value === '') {
-        translations.set(key, `•${key}•`);
+      } else {
+        if (!translations.has(text)) {
+          translations.set(text, `•${text}•`);
+        }
+        const generatedId = this.generateTranslationID(row);
+        if (id && id !== generatedId && !translations.has(id)) {
+          translations.set(id, `•${id}•`);
+        }
       }
     }
     const json = Object.fromEntries(translations);

--- a/apps/picsa-server/supabase/migrations/20260717161900_add_country_code_to_translations.sql
+++ b/apps/picsa-server/supabase/migrations/20260717161900_add_country_code_to_translations.sql
@@ -1,0 +1,5 @@
+-- Add country_code column referencing the existing country_code enum type
+ALTER TABLE public.translations ADD COLUMN country_code public.country_code;
+
+-- Drop the old unique constraint
+ALTER TABLE public.translations DROP CONSTRAINT IF EXISTS translations_tool_context_en_key;

--- a/apps/picsa-server/supabase/types/db.types.ts
+++ b/apps/picsa-server/supabase/types/db.types.ts
@@ -1009,6 +1009,7 @@ export type Database = {
         Row: {
           archived: boolean | null;
           context: string | null;
+          country_code: Database['public']['Enums']['country_code'] | null;
           created_at: string;
           id: string;
           ke_sw: string | null;
@@ -1029,6 +1030,7 @@ export type Database = {
         Insert: {
           archived?: boolean | null;
           context?: string | null;
+          country_code?: Database['public']['Enums']['country_code'] | null;
           created_at?: string;
           id: string;
           ke_sw?: string | null;
@@ -1049,6 +1051,7 @@ export type Database = {
         Update: {
           archived?: boolean | null;
           context?: string | null;
+          country_code?: Database['public']['Enums']['country_code'] | null;
           created_at?: string;
           id?: string;
           ke_sw?: string | null;
@@ -1408,7 +1411,6 @@ export type Database = {
           created_at: string | null;
           id: string;
           last_accessed_at: string | null;
-          level: number | null;
           metadata: Json | null;
           name: string | null;
           owner: string | null;
@@ -1423,7 +1425,6 @@ export type Database = {
           created_at?: string | null;
           id?: string;
           last_accessed_at?: string | null;
-          level?: number | null;
           metadata?: Json | null;
           name?: string | null;
           owner?: string | null;
@@ -1438,7 +1439,6 @@ export type Database = {
           created_at?: string | null;
           id?: string;
           last_accessed_at?: string | null;
-          level?: number | null;
           metadata?: Json | null;
           name?: string | null;
           owner?: string | null;
@@ -1458,38 +1458,6 @@ export type Database = {
           },
         ];
       };
-      prefixes: {
-        Row: {
-          bucket_id: string;
-          created_at: string | null;
-          level: number;
-          name: string;
-          updated_at: string | null;
-        };
-        Insert: {
-          bucket_id: string;
-          created_at?: string | null;
-          level?: number;
-          name: string;
-          updated_at?: string | null;
-        };
-        Update: {
-          bucket_id?: string;
-          created_at?: string | null;
-          level?: number;
-          name?: string;
-          updated_at?: string | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: 'prefixes_bucketId_fkey';
-            columns: ['bucket_id'];
-            isOneToOne: false;
-            referencedRelation: 'buckets';
-            referencedColumns: ['id'];
-          },
-        ];
-      };
       s3_multipart_uploads: {
         Row: {
           bucket_id: string;
@@ -1497,6 +1465,7 @@ export type Database = {
           id: string;
           in_progress_size: number;
           key: string;
+          metadata: Json | null;
           owner_id: string | null;
           upload_signature: string;
           user_metadata: Json | null;
@@ -1508,6 +1477,7 @@ export type Database = {
           id: string;
           in_progress_size?: number;
           key: string;
+          metadata?: Json | null;
           owner_id?: string | null;
           upload_signature: string;
           user_metadata?: Json | null;
@@ -1519,6 +1489,7 @@ export type Database = {
           id?: string;
           in_progress_size?: number;
           key?: string;
+          metadata?: Json | null;
           owner_id?: string | null;
           upload_signature?: string;
           user_metadata?: Json | null;
@@ -1637,28 +1608,25 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
-      add_prefixes: {
-        Args: { _bucket_id: string; _name: string };
-        Returns: undefined;
+      allow_any_operation: {
+        Args: { expected_operations: string[] };
+        Returns: boolean;
+      };
+      allow_only_operation: {
+        Args: { expected_operation: string };
+        Returns: boolean;
       };
       can_insert_object: {
         Args: { bucketid: string; metadata: Json; name: string; owner: string };
         Returns: undefined;
       };
-      delete_leaf_prefixes: {
-        Args: { bucket_ids: string[]; names: string[] };
-        Returns: undefined;
-      };
-      delete_prefix: {
-        Args: { _bucket_id: string; _name: string };
-        Returns: boolean;
-      };
       extension: { Args: { name: string }; Returns: string };
       filename: { Args: { name: string }; Returns: string };
       foldername: { Args: { name: string }; Returns: string[] };
-      get_level: { Args: { name: string }; Returns: number };
-      get_prefix: { Args: { name: string }; Returns: string };
-      get_prefixes: { Args: { name: string }; Returns: string[] };
+      get_common_prefix: {
+        Args: { p_delimiter: string; p_key: string; p_prefix: string };
+        Returns: string;
+      };
       get_size_by_bucket: {
         Args: never;
         Returns: {
@@ -1683,64 +1651,25 @@ export type Database = {
       };
       list_objects_with_delimiter: {
         Args: {
-          bucket_id: string;
+          _bucket_id: string;
           delimiter_param: string;
           max_keys?: number;
           next_token?: string;
           prefix_param: string;
+          sort_order?: string;
           start_after?: string;
         };
         Returns: {
+          created_at: string;
           id: string;
+          last_accessed_at: string;
           metadata: Json;
           name: string;
           updated_at: string;
         }[];
-      };
-      lock_top_prefixes: {
-        Args: { bucket_ids: string[]; names: string[] };
-        Returns: undefined;
       };
       operation: { Args: never; Returns: string };
-      search:
-        | {
-            Args: {
-              bucketname: string;
-              levels?: number;
-              limits?: number;
-              offsets?: number;
-              prefix: string;
-            };
-            Returns: {
-              created_at: string;
-              id: string;
-              last_accessed_at: string;
-              metadata: Json;
-              name: string;
-              updated_at: string;
-            }[];
-          }
-        | {
-            Args: {
-              bucketname: string;
-              levels?: number;
-              limits?: number;
-              offsets?: number;
-              prefix: string;
-              search?: string;
-              sortcolumn?: string;
-              sortorder?: string;
-            };
-            Returns: {
-              created_at: string;
-              id: string;
-              last_accessed_at: string;
-              metadata: Json;
-              name: string;
-              updated_at: string;
-            }[];
-          };
-      search_legacy_v1: {
+      search: {
         Args: {
           bucketname: string;
           levels?: number;
@@ -1760,65 +1689,48 @@ export type Database = {
           updated_at: string;
         }[];
       };
-      search_v1_optimised: {
+      search_by_timestamp: {
         Args: {
-          bucketname: string;
-          levels?: number;
-          limits?: number;
-          offsets?: number;
-          prefix: string;
-          search?: string;
-          sortcolumn?: string;
-          sortorder?: string;
+          p_bucket_id: string;
+          p_level: number;
+          p_limit: number;
+          p_prefix: string;
+          p_sort_column: string;
+          p_sort_column_after: string;
+          p_sort_order: string;
+          p_start_after: string;
         };
         Returns: {
           created_at: string;
           id: string;
+          key: string;
           last_accessed_at: string;
           metadata: Json;
           name: string;
           updated_at: string;
         }[];
       };
-      search_v2:
-        | {
-            Args: {
-              bucket_name: string;
-              levels?: number;
-              limits?: number;
-              prefix: string;
-              start_after?: string;
-            };
-            Returns: {
-              created_at: string;
-              id: string;
-              key: string;
-              metadata: Json;
-              name: string;
-              updated_at: string;
-            }[];
-          }
-        | {
-            Args: {
-              bucket_name: string;
-              levels?: number;
-              limits?: number;
-              prefix: string;
-              sort_column?: string;
-              sort_column_after?: string;
-              sort_order?: string;
-              start_after?: string;
-            };
-            Returns: {
-              created_at: string;
-              id: string;
-              key: string;
-              last_accessed_at: string;
-              metadata: Json;
-              name: string;
-              updated_at: string;
-            }[];
-          };
+      search_v2: {
+        Args: {
+          bucket_name: string;
+          levels?: number;
+          limits?: number;
+          prefix: string;
+          sort_column?: string;
+          sort_column_after?: string;
+          sort_order?: string;
+          start_after?: string;
+        };
+        Returns: {
+          created_at: string;
+          id: string;
+          key: string;
+          last_accessed_at: string;
+          metadata: Json;
+          name: string;
+          updated_at: string;
+        }[];
+      };
     };
     Enums: {
       buckettype: 'STANDARD' | 'ANALYTICS' | 'VECTOR';

--- a/libs/data/climate/chart_definitions/default.ts
+++ b/libs/data/climate/chart_definitions/default.ts
@@ -1,9 +1,9 @@
 import { IChartDefinitions, IChartMeta } from '@picsa/models';
-import merge from 'deepmerge';
+import { deepClone } from '@picsa/utils';
 import { marker as translateMarker } from '@biesbjerg/ngx-translate-extract-marker';
+import merge from 'deepmerge';
 
 import { LINE_TOOL_COLORS, LINE_TOOL_OPTIONS, PROBABILITY_TOOL_OPTIONS } from '../tool_definitions';
-import { deepClone } from '@picsa/utils';
 
 const tools: IChartMeta['tools'] = {
   line: LINE_TOOL_OPTIONS,
@@ -25,13 +25,13 @@ const AXES_DEFAULT: IChartMeta['axes'] = {
 const definitions: IChartDefinitions = {
   rainfall: {
     _id: 'rainfall',
-    name: 'Seasonal Rainfall',
-    shortname: 'Rain',
+    name: translateMarker('Seasonal Rainfall'),
+    shortname: translateMarker('Rain'),
     image: 'assets/climate-icons/season-rainfall.png',
     keys: ['Rainfall'],
     colors: ['#377eb8'],
     yFormat: 'value',
-    yLabel: 'Seasonal Total Rainfall (mm)',
+    yLabel: translateMarker('Seasonal Total Rainfall (mm)'),
     xLabel: '',
     xVar: 'Year',
     axes: {
@@ -42,18 +42,17 @@ const definitions: IChartDefinitions = {
     },
     tools,
     units: 'mm',
-    definition:
-      'Seasonal rainfall is defined as the total rain recorded from the start of the season until the end of the season',
+    definition: '',
   },
   start: {
     _id: 'start',
-    name: 'Start of Season',
-    shortname: 'Start',
+    name: translateMarker('Start of Season'),
+    shortname: translateMarker('Start'),
     image: 'assets/climate-icons/season-start.png',
     keys: ['Start'],
     colors: ['#e41a1c'],
     yFormat: 'date-from-July',
-    yLabel: 'Start of Season',
+    yLabel: translateMarker('Start of Season'),
     xLabel: '',
     xVar: 'Year',
     axes: {
@@ -66,24 +65,23 @@ const definitions: IChartDefinitions = {
       // start of season focuses more on values below line. Use different colors to emphasise change
       line: { above: { color: LINE_TOOL_COLORS.red }, below: { color: LINE_TOOL_COLORS.purple } },
       probability: {
-        above: { color: LINE_TOOL_COLORS.red, label: 'After' },
-        below: { color: LINE_TOOL_COLORS.purple, label: 'Before' },
+        above: { color: LINE_TOOL_COLORS.red, label: translateMarker('After') },
+        below: { color: LINE_TOOL_COLORS.purple, label: translateMarker('Before') },
         reverse: true,
       },
     }),
     units: '',
-    definition:
-      'Start of season is defined as the first occasion (from 1st October) with more than 25mm in a 3 day period and no dry spell of 10 days or more within the following 30 days',
+    definition: '',
   },
   end: {
     _id: 'end',
-    name: 'End of Season',
-    shortname: 'End',
+    name: translateMarker('End of Season'),
+    shortname: translateMarker('End'),
     image: 'assets/climate-icons/season-end.png',
     keys: ['End'],
     colors: ['#984ea3'],
     yFormat: 'date-from-July',
-    yLabel: 'End of Season',
+    yLabel: translateMarker('End of Season'),
     xLabel: '',
     xVar: 'Year',
     axes: {
@@ -102,18 +100,17 @@ const definitions: IChartDefinitions = {
       },
     }),
     units: '',
-    definition:
-      'End of season is defined as the last day in the season (1st October - 30th April) with more than 10mm of rainfall.',
+    definition: '',
   },
   length: {
     _id: 'length',
-    name: 'Length of Season',
-    shortname: 'Length',
+    name: translateMarker('Length of Season'),
+    shortname: translateMarker('Length'),
     image: 'assets/climate-icons/season-length.png',
     keys: ['Length'],
     colors: ['#4daf4a'],
     yFormat: 'value',
-    yLabel: 'Length of Season',
+    yLabel: translateMarker('Length of Season'),
     xLabel: '',
     xVar: 'Year',
     axes: {
@@ -123,19 +120,18 @@ const definitions: IChartDefinitions = {
     },
     tools,
     units: 'days',
-    definition:
-      'Length of season is defined as the total days from the start of the season until the end of the season as defined',
+    definition: '',
   },
   extreme_rainfall_days: {
     _id: 'extreme_rainfall_days',
     disabled: true,
-    name: 'Extreme Rainfall',
-    shortname: 'Extreme',
+    name: translateMarker('Extreme Rainfall'),
+    shortname: translateMarker('Extreme'),
     image: 'assets/climate-icons/extreme-rainfall.svg',
     keys: ['Extreme_events'],
     colors: ['#0a3a62'],
     yFormat: 'value',
-    yLabel: 'Frequency of Extreme',
+    yLabel: translateMarker('Frequency of Extreme'),
     xLabel: 'Year',
     xVar: 'Year',
     axes: {
@@ -145,7 +141,7 @@ const definitions: IChartDefinitions = {
     },
     tools,
     units: 'days',
-    definition: 'Extreme rainfall are days where the total amount of rain exceeds the 95th Percentile',
+    definition: '',
   },
   temp_min: {
     _id: 'temp_min',
@@ -161,7 +157,7 @@ const definitions: IChartDefinitions = {
     yFormat: 'value',
     yLabel: translateMarker('Temperature (°C)'),
     xLabel: '',
-    xVar: translateMarker('Year'),
+    xVar: 'Year',
     axes: {
       ...AXES_DEFAULT,
       yMinor: 1,
@@ -171,7 +167,7 @@ const definitions: IChartDefinitions = {
     legend: { show: true },
     tools: {} as any,
     units: '°C',
-    definition: translateMarker('The mean minimum and lowest minimum daily temperatures per year'),
+    definition: '',
   },
   temp_max: {
     _id: 'temp_max',
@@ -187,7 +183,7 @@ const definitions: IChartDefinitions = {
     yFormat: 'value',
     yLabel: translateMarker('Temperature (°C)'),
     xLabel: '',
-    xVar: translateMarker('Year'),
+    xVar: 'Year',
     axes: {
       ...AXES_DEFAULT,
       yMinor: 1,
@@ -197,7 +193,7 @@ const definitions: IChartDefinitions = {
     legend: { show: true },
     tools: {} as any,
     units: '°C',
-    definition: translateMarker('The mean maximum and highest maximum daily temperatures per year'),
+    definition: '',
   },
 };
 

--- a/libs/data/climate/chart_definitions/mw.ts
+++ b/libs/data/climate/chart_definitions/mw.ts
@@ -4,12 +4,12 @@ const definitions = DEFAULT_DEFINITIONS();
 
 definitions.extreme_rainfall_days.keys = ['sum_RD50' as any];
 
-definitions.end.definition = 'Last occurance between 1 Oct and 30 Apr with 10 mm rainfall';
+definitions.end.definition = 'Last occurence between 1 Oct and 30 Apr with 10 mm rainfall';
 definitions.extreme_rainfall_days.definition = 'Rainy days with at least 50mm';
 definitions.length.definition = 'Number of days between start and end of the rains';
 definitions.rainfall.definition = 'Total rainfall per year from start of the rains to end of the season';
 definitions.start.definition =
-  'First occurance from 1 Oct with at least 25 mm of rainfall over 3 consecutive days (with no dry spell of length 9 in the next 21 days)';
+  'First occurence from 1 Oct with at least 25 mm of rainfall over 3 consecutive days (with no dry spell of length 9 in the next 21 days)';
 definitions.temp_max.definition = 'The mean maximum and highest maximum daily temperatures per year';
 definitions.temp_min.definition = 'The mean minimum and lowest minimum daily temperatures per year';
 

--- a/libs/data/climate/chart_definitions/mw.ts
+++ b/libs/data/climate/chart_definitions/mw.ts
@@ -3,7 +3,15 @@ import DEFAULT_DEFINITIONS from './default';
 const definitions = DEFAULT_DEFINITIONS();
 
 definitions.extreme_rainfall_days.keys = ['sum_RD50' as any];
+
+definitions.end.definition = 'Last occurance between 1 Oct and 30 Apr with 10 mm rainfall';
 definitions.extreme_rainfall_days.definition = 'Rainy days with at least 50mm';
+definitions.length.definition = 'Number of days between start and end of the rains';
+definitions.rainfall.definition = 'Total rainfall per year from start of the rains to end of the season';
+definitions.start.definition =
+  'First occurance from 1 Oct with at least 25 mm of rainfall over 3 consecutive days (with no dry spell of length 9 in the next 21 days)';
+definitions.temp_max.definition = 'The mean maximum and highest maximum daily temperatures per year';
+definitions.temp_min.definition = 'The mean minimum and lowest minimum daily temperatures per year';
 
 // Provide country-specific overrides for definitions and labels
 

--- a/libs/data/climate/chart_definitions/zm.ts
+++ b/libs/data/climate/chart_definitions/zm.ts
@@ -3,12 +3,12 @@ import DEFAULT_DEFINITIONS from './default';
 const definitions = DEFAULT_DEFINITIONS();
 
 definitions.end.definition =
-  'First occurance from 1 Mar where water balance reduces to 0.5 mm from an initial capacity of 100mm with an assumed evaporation rate of 5mm/day';
+  'First occurence from 1 Mar where water balance reduces to 0.5 mm from an initial capacity of 100mm with an assumed evaporation rate of 5mm/day';
 definitions.extreme_rainfall_days.definition = '';
 definitions.length.definition = 'Number of days between start of the rains and end of the season';
 definitions.rainfall.definition = 'Total rainfall per year from start of the rains to end of the season';
 definitions.start.definition =
-  'First occurance from 1 Oct with at least 20 mm of rainfall over 3 consecutive days (with no dry spell of length 9 in the next 21 days)';
+  'First occurence from 1 Oct with at least 20 mm of rainfall over 3 consecutive days (with no dry spell of length 9 in the next 21 days)';
 definitions.temp_max.definition = 'The mean maximum and highest maximum daily temperatures per year';
 definitions.temp_min.definition = 'The mean minimum and lowest minimum daily temperatures per year';
 

--- a/libs/data/climate/chart_definitions/zm.ts
+++ b/libs/data/climate/chart_definitions/zm.ts
@@ -1,21 +1,15 @@
-import { marker as translateMarker } from '@biesbjerg/ngx-translate-extract-marker';
-
 import DEFAULT_DEFINITIONS from './default';
 
 const definitions = DEFAULT_DEFINITIONS();
 
-// Provide country-specific overrides for definitions and labels
-definitions.rainfall.definition = translateMarker(
-  'Seasonal total rainfall calculated between the defined start and defined end of the season',
-);
-definitions.length.definition = translateMarker(
-  'Calculated with the date range of Start of rains and End of the rains',
-);
-definitions.start.definition = translateMarker(
-  'First 3 days receiving rainfall amount of 20mm and not followed by 9-day dry spell for the next 21 days',
-);
-definitions.end.definition = translateMarker(
-  'Capacity of 100mm on 1st March reduces 0.5 with evaporation rate of 5mm per day',
-);
+definitions.end.definition =
+  'First occurance from 1 Mar where water balance reduces to 0.5 mm from an initial capacity of 100mm with an assumed evaporation rate of 5mm/day';
+definitions.extreme_rainfall_days.definition = '';
+definitions.length.definition = 'Number of days between start of the rains and end of the season';
+definitions.rainfall.definition = 'Total rainfall per year from start of the rains to end of the season';
+definitions.start.definition =
+  'First occurance from 1 Oct with at least 20 mm of rainfall over 3 consecutive days (with no dry spell of length 9 in the next 21 days)';
+definitions.temp_max.definition = 'The mean maximum and highest maximum daily temperatures per year';
+definitions.temp_min.definition = 'The mean minimum and lowest minimum daily temperatures per year';
 
 export default definitions;

--- a/libs/data/climate/chart_definitions/zw.ts
+++ b/libs/data/climate/chart_definitions/zw.ts
@@ -2,12 +2,13 @@ import DEFAULT_DEFINITIONS from './default';
 
 const definitions = DEFAULT_DEFINITIONS();
 
-// Provide country-specific overrides for definitions and labels
-
-definitions.start.definition =
-  'First occasion, after start of rains and before 31 Jan with more than 20mm rain in 3 days and no dry spell longer than 10 days in the next 21 days';
-
 definitions.end.definition =
   'First occasion, after end of rains and before 30 June when soil moisture level is less than zero';
+definitions.extreme_rainfall_days.definition = '';
+definitions.length.definition = 'Number of days from Start of Season to End of Season';
+definitions.rainfall.definition = 'Seasonal rainfall totalled from 1 Oct to 30 Apr';
+definitions.start.definition = 'First occasion, from 1 Oct to 31 Jan, with more than 20 mm of rainfall in 3 days';
+definitions.temp_max.definition = 'The mean maximum and highest maximum daily temperatures per year';
+definitions.temp_min.definition = 'The mean minimum and lowest minimum daily temperatures per year';
 
 export default definitions;

--- a/libs/i18n-gen/src/generate.ts
+++ b/libs/i18n-gen/src/generate.ts
@@ -62,7 +62,12 @@ function generateTranslationTemplates() {
   for (const el of ordered) {
     unique[el.text] = el;
   }
-  const output = Object.values(unique);
+  // Reorder alphabetically by tool
+  const output = Object.values(unique).sort((a, b) => {
+    const keyA = `${a.tool}.${a.id}.${a.text}`;
+    const keyB = `${b.tool}.${b.id}.${b.text}`;
+    return keyA > keyB ? 1 : -1;
+  });
   writeFileSync(TEMPLATE_PATH, JSON.stringify(output, null, 2));
 }
 

--- a/libs/i18n-gen/src/hardcoded/climate.ts
+++ b/libs/i18n-gen/src/hardcoded/climate.ts
@@ -1,15 +1,30 @@
-import DEFAULT_DEFINITIONS from '@picsa/data/climate/chart_definitions/default';
+import { ICountryCode } from '@picsa/data';
+import { CLIMATE_CHART_DEFINITIONS } from '@picsa/data/climate/chart_definitions';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import type { IChartMeta } from '@picsa/models';
 
 import type { ITranslationEntry } from '../types';
 
 const entries: ITranslationEntry[] = [];
-const definitions = Object.values(DEFAULT_DEFINITIONS());
 
-for (const el of definitions) {
-  entries.push({ text: el.name, tool: 'climate', context: 'chart' });
-  entries.push({ text: el.shortname, tool: 'climate', context: 'chart' });
-  entries.push({ text: el.yLabel, tool: 'climate', context: 'chart' });
-  entries.push({ text: el.definition, tool: 'climate', context: 'chart' });
+const { default: defaultDefs, ...allCountryDefs } = CLIMATE_CHART_DEFINITIONS;
+
+const extractedKeys: (keyof IChartMeta)[] = ['definition'];
+
+// populate per-country overrides of chart definitions
+for (const chartId of Object.keys(defaultDefs)) {
+  for (const key of extractedKeys) {
+    for (const [countryCode, countryDefs] of Object.entries(allCountryDefs)) {
+      const text = countryDefs[chartId]?.[key] || '';
+      const id = `${countryCode}:climate.chart.${chartId}.${key}`;
+      entries.push({
+        id,
+        text,
+        tool: 'climate',
+        country_code: countryCode as ICountryCode,
+      });
+    }
+  }
 }
 
 export const CLIMATE_ENTRIES = entries;

--- a/libs/i18n-gen/src/hardcoded/index.ts
+++ b/libs/i18n-gen/src/hardcoded/index.ts
@@ -49,4 +49,8 @@ export const EXTRACTED_PROJECTS: { path: string; tool: string; context?: string 
     path: 'libs',
     tool: 'common',
   },
+  {
+    path: 'libs/data/climate',
+    tool: 'climate',
+  },
 ];

--- a/libs/i18n-gen/src/types.ts
+++ b/libs/i18n-gen/src/types.ts
@@ -1,4 +1,10 @@
+import { ICountryCode } from '@picsa/data';
+
 export interface ITranslationEntry {
+  /** generated or manually defined id */
+  id?: string;
+  /** specific country where translation applies (default global) */
+  country_code?: ICountryCode | null;
   /** case-sensitive string representation for translation */
   text: string;
   /** associated tool for context */


### PR DESCRIPTION
## Description

This pull request introduces country-specific translation overrides by adding a country_code column to the translations table and updating the TranslationDashboardService to filter translations based on the active deployment. It also refactors climate chart definitions to separate default and country-specific text, and updates the translation import/export logic

## Related Issues

> Link any related issues (e.g., `Closes #123`, `Relates to #456`)

## Discussion

> Any key points for discussion with UoR team or other devs

## Use of AI

> Share any comments related to use of ai, such as tools or models used to help generate code, pain points, challenges etc.
> These comments will be discussed during monthly stand-up to support development

## Screenshots / Videos

> Include at least 1-2 screenshots of videos if visual changes
