### PR TITLE
fix: functions dev availability

### DIFF
--- a/libs/shared/src/services/core/supabase/services/supabase-functions.service.spec.ts
+++ b/libs/shared/src/services/core/supabase/services/supabase-functions.service.spec.ts
@@ -1,0 +1,71 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { FunctionsHttpError } from '@supabase/supabase-js';
+
+import { SupabaseFunctionsService } from './supabase-functions.service';
+
+describe('SupabaseFunctionsService', () => {
+  let service: SupabaseFunctionsService;
+  let mockSupabaseClient: any;
+  let mockInvoke: jest.Mock;
+
+  beforeEach(() => {
+    mockInvoke = jest.fn();
+    mockSupabaseClient = {
+      functions: {
+        invoke: mockInvoke,
+      },
+    };
+
+    service = new SupabaseFunctionsService();
+    service.registerSupabaseClient(mockSupabaseClient as unknown as SupabaseClient);
+  });
+
+  it('should return response data on successful invocation', async () => {
+    mockInvoke.mockResolvedValue({ data: { success: true }, error: null });
+
+    const result = await service.invoke<{ success: boolean }>('test-endpoint');
+
+    expect(result).toEqual({ success: true });
+    expect(mockInvoke).toHaveBeenCalledWith(
+      'test-endpoint',
+      expect.objectContaining({
+        method: 'POST',
+        body: {},
+      }),
+    );
+  });
+
+  it('should include custom headers set via setHeaders', async () => {
+    mockInvoke.mockResolvedValue({ data: { success: true }, error: null });
+
+    service.setHeaders({ deployment_id: 'dep-123' });
+    await service.invoke('test-endpoint');
+
+    expect(mockInvoke).toHaveBeenCalledWith(
+      'test-endpoint',
+      expect.objectContaining({
+        headers: { 'x-picsa-deployment-id': 'dep-123' },
+      }),
+    );
+  });
+
+  it('should throw helpful error message in local dev when functions endpoint is not running', async () => {
+    const error = new FunctionsHttpError({
+      json: () => Promise.resolve({ error: 'name resolution failed' }),
+    } as any);
+    mockInvoke.mockResolvedValue({ data: null, error });
+
+    await expect(service.invoke('test-endpoint')).rejects.toThrow(
+      'Supabase Edge Functions endpoint is not running locally.\nPlease start it using: yarn nx run picsa-server:supabase functions serve',
+    );
+  });
+
+  it('should throw original error message when error is not due to functions endpoint being down', async () => {
+    const error = new FunctionsHttpError({
+      json: () => Promise.resolve({ message: 'User not authorized' }),
+    } as any);
+    mockInvoke.mockResolvedValue({ data: null, error });
+
+    await expect(service.invoke('test-endpoint')).rejects.toThrow('User not authorized');
+  });
+});

--- a/libs/shared/src/services/core/supabase/services/supabase-functions.service.ts
+++ b/libs/shared/src/services/core/supabase/services/supabase-functions.service.ts
@@ -60,8 +60,8 @@ export class SupabaseFunctionsService extends SupabaseDeferredClient {
     const isOffline =
       error instanceof FunctionsFetchError ||
       error instanceof FunctionsRelayError ||
-      errorMessage?.toLowerCase().includes('name resolution failed') ||
-      errorMessage?.toLowerCase().includes('failed to send a request to the edge function');
+      errorMessage?.toLowerCase()?.includes('name resolution failed') ||
+      errorMessage?.toLowerCase()?.includes('failed to send a request to the edge function');
 
     if (!ENVIRONMENT.production && isOffline) {
       throw new Error(
@@ -69,6 +69,6 @@ export class SupabaseFunctionsService extends SupabaseDeferredClient {
       );
     }
 
-    throw new Error(errorMessage);
+    throw new Error(errorMessage || error.message || 'An unknown error occurred');
   }
 }

--- a/libs/shared/src/services/core/supabase/services/supabase-functions.service.ts
+++ b/libs/shared/src/services/core/supabase/services/supabase-functions.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
+import { ENVIRONMENT } from '@picsa/environments';
 import type { FunctionInvokeOptions } from '@supabase/functions-js';
-import { FunctionsHttpError } from '@supabase/supabase-js';
+import { FunctionsFetchError, FunctionsHttpError, FunctionsRelayError } from '@supabase/supabase-js';
 
 import { SupabaseDeferredClient } from './deferred-client';
 
@@ -35,14 +36,39 @@ export class SupabaseFunctionsService extends SupabaseDeferredClient {
       headers: { ...this.headers, ...options.headers },
     });
 
-    // Errors thrown from functions in JS client need to wait for message
-    // https://github.com/supabase/functions-js/issues/45
-    if (error && error instanceof FunctionsHttpError) {
-      const errorPayload = await error.context.json();
-      const errorMessage = errorPayload?.message || errorPayload?.error || JSON.stringify(errorPayload);
-      throw new Error(errorMessage);
+    if (error) {
+      await this.handleFunctionsError(error);
     }
 
     return data as ResponseType;
+  }
+
+  private async handleFunctionsError(error: any): Promise<never> {
+    let errorMessage = error.message;
+
+    // Errors thrown from functions in JS client need to wait for message
+    // https://github.com/supabase/functions-js/issues/45
+    if (error instanceof FunctionsHttpError) {
+      try {
+        const errorPayload = await error.context.json();
+        errorMessage = errorPayload?.message || errorPayload?.error || JSON.stringify(errorPayload);
+      } catch {
+        // context.json() may fail if response body is not valid JSON
+      }
+    }
+
+    const isOffline =
+      error instanceof FunctionsFetchError ||
+      error instanceof FunctionsRelayError ||
+      errorMessage?.toLowerCase().includes('name resolution failed') ||
+      errorMessage?.toLowerCase().includes('failed to send a request to the edge function');
+
+    if (!ENVIRONMENT.production && isOffline) {
+      throw new Error(
+        `Supabase Edge Functions endpoint is not running locally.\nPlease start it using: yarn nx run picsa-server:supabase functions serve`,
+      );
+    }
+
+    throw new Error(errorMessage);
   }
 }


### PR DESCRIPTION
## Developer Summary

> Info for reviewer, e.g. use of ai, pain points/challenges, discussion points for monthly dev call

## Related Issues

> Link any related issues (e.g., `Closes #[issue_number]`, `Relates to #[issue_number]`)

## Screenshots / Videos

> Include at least 1-2 screenshots of videos if visual changes

---

## AI Summary

> Will be generated on PR open. Regenerate by typing comment `/describe` in PR
> More info at https://docs.pr-agent.ai/tools/describe/

### Description

### 🤖 Generated by PR Agent at fe4f5192a444f861946cdd3ff4357bc81c9efd40

- Improve local development error handling for Supabase functions.
- Detect offline Supabase Edge Functions in non-prod.
- Provide clear instructions to start local functions.
- Add unit tests for Supabase functions service.


### Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>supabase-functions.service.ts</strong><dd><code>Enhance Supabase functions error handling for local development</code></dd></summary>
<hr>

libs/shared/src/services/core/supabase/services/supabase-functions.service.ts

<ul><li>Refactored error handling into a dedicated <code>handleFunctionsError</code> <br>method.<br> <li> Added checks for <code>FunctionsFetchError</code>, <code>FunctionsRelayError</code>, and <br>specific offline error messages.<br> <li> Throws a helpful instruction message to start Supabase functions <br>locally when offline in non-production environments.</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/654/files#diff-2397d828d5049247a5f8d98b47c8fa7b845ce141911bbfcfc550c766b5fe9e26">+32/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>supabase-functions.service.spec.ts</strong><dd><code>Add unit tests for Supabase functions service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/shared/src/services/core/supabase/services/supabase-functions.service.spec.ts

<ul><li>Created a new test suite for <code>SupabaseFunctionsService</code>.<br> <li> Added tests for successful invocation and custom headers.<br> <li> Added tests verifying the helpful local development error message and <br>standard error propagation.</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/654/files#diff-a100a6742a260fe3347aac36bc5b10f2efcce3705bea9e5e30c9f357bc3eed19">+71/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

### Diagram


```mermaid
flowchart LR
  node1["SupabaseFunctionsService.invoke()"] -- "catches error" --> node2["handleFunctionsError()"]
  node2 -- "offline & non-prod" --> node3["Throw local setup instructions"]
  node2 -- "other errors" --> node4["Throw original error message"]
```

#