### PR TITLE
feat(dashboard): permission table user details

### DIFF
--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/user-permissions/user-permissions.component.html
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/user-permissions/user-permissions.component.html
@@ -24,6 +24,7 @@
         [data]="pendingRequestsDetails()"
         [options]="pendingRequestsTableOptions"
         [valueTemplates]="{
+          user: userTemplate,
           created_at: dateTemplate,
           actions: pendingActionsTemplate,
         }"
@@ -45,6 +46,7 @@
     [data]="deploymentUsers()"
     [options]="matrixTableOptions"
     [valueTemplates]="{
+      user: userTemplate,
       admin: permissionTemplate,
       climate: permissionTemplate,
       resources: permissionTemplate,
@@ -54,6 +56,23 @@
       actions: actionsTemplate,
     }"
   >
+    <ng-template #userTemplate let-row="row">
+      <div class="flex flex-col py-1">
+        <div class="font-medium">
+          {{ row.full_name || row.email || 'Unknown User' }}
+        </div>
+        <div class="text-xs text-secondary">
+          @if (row.full_name && row.organisation) {
+            {{ row.organisation }}<br />{{ row.email }}
+          } @else if (row.organisation) {
+            {{ row.organisation }}
+          } @else if (row.full_name) {
+            {{ row.email }}
+          }
+        </div>
+      </div>
+    </ng-template>
+
     <ng-template #permissionTemplate let-column="column" let-row="row">
       <div class="flex justify-center">
         <!-- Use matIconButton for interactive elements -->
@@ -124,7 +143,10 @@
     <picsa-data-table
       [data]="allUsers()"
       [options]="allUserTableOptions"
-      [valueTemplates]="{ isMember: memberTemplate }"
+      [valueTemplates]="{
+        user: userTemplate,
+        isMember: memberTemplate,
+      }"
     >
       <ng-template #memberTemplate let-isMember let-row="row">
         <button matButton [disabled]="isMember" mat-dialog-close (click)="addUser(row)">

--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/user-permissions/user-permissions.component.html
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/user-permissions/user-permissions.component.html
@@ -15,6 +15,24 @@
     </div>
   </div>
 
+  <!-- User table entry template (used in multiple tables) -->
+  <ng-template #userTemplate let-row="row">
+    <div class="flex flex-col py-1">
+      <div class="font-medium">
+        {{ row.full_name || row.email || 'Unknown User' }}
+      </div>
+      <div class="text-xs text-secondary">
+        @if (row.full_name && row.organisation) {
+          {{ row.organisation }}<br />{{ row.email }}
+        } @else if (row.organisation) {
+          {{ row.organisation }}
+        } @else if (row.full_name) {
+          {{ row.email }}
+        }
+      </div>
+    </div>
+  </ng-template>
+
   @if (pendingRequestsDetails().length > 0) {
     <div class="mb-8">
       <h3 class="text-warn mb-4 flex items-center gap-2">
@@ -56,23 +74,6 @@
       actions: actionsTemplate,
     }"
   >
-    <ng-template #userTemplate let-row="row">
-      <div class="flex flex-col py-1">
-        <div class="font-medium">
-          {{ row.full_name || row.email || 'Unknown User' }}
-        </div>
-        <div class="text-xs text-secondary">
-          @if (row.full_name && row.organisation) {
-            {{ row.organisation }}<br />{{ row.email }}
-          } @else if (row.organisation) {
-            {{ row.organisation }}
-          } @else if (row.full_name) {
-            {{ row.email }}
-          }
-        </div>
-      </div>
-    </ng-template>
-
     <ng-template #permissionTemplate let-column="column" let-row="row">
       <div class="flex justify-center">
         <!-- Use matIconButton for interactive elements -->

--- a/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/user-permissions/user-permissions.component.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/deployment/pages/user-permissions/user-permissions.component.ts
@@ -65,7 +65,7 @@ export class DeploymentUserPermissionsComponent implements OnInit {
   });
 
   public allUserTableOptions: IDataTableOptions = {
-    displayColumns: ['email', 'isMember'],
+    displayColumns: ['user', 'isMember'],
     formatHeader: (header) => {
       if (header === 'isMember') return '';
       return formatHeaderDefault(header);
@@ -82,12 +82,14 @@ export class DeploymentUserPermissionsComponent implements OnInit {
       return {
         ...r,
         email: u ? u.email : 'Unknown User',
+        full_name: u?.full_name,
+        organisation: u?.organisation,
       };
     });
   });
 
   public pendingRequestsTableOptions: IDataTableOptions = {
-    displayColumns: ['email', 'created_at', 'actions'],
+    displayColumns: ['user', 'created_at', 'actions'],
     formatHeader: (header) => {
       if (header === 'actions') return '';
       if (header === 'created_at') return 'Requested At';
@@ -99,7 +101,7 @@ export class DeploymentUserPermissionsComponent implements OnInit {
   public deploymentUsers = computed(() => this.allUsers().filter((u) => u.isMember));
 
   public matrixTableOptions: IDataTableOptions = {
-    displayColumns: ['email', 'admin', 'climate', 'resources', 'crop', 'translations', 'deployments', 'actions'],
+    displayColumns: ['user', 'admin', 'climate', 'resources', 'crop', 'translations', 'deployments', 'actions'],
     formatHeader: (header) => {
       if (header === 'actions') return '';
       if (header === 'admin') return 'Global Admin';

--- a/apps/picsa-server/supabase/functions/dashboard/admin/types.ts
+++ b/apps/picsa-server/supabase/functions/dashboard/admin/types.ts
@@ -1,11 +1,6 @@
 import type { Database } from '../../../types/db.types.ts';
 
 // Partial auth user data shared
-export type IAdminListUsersResponse = {
-  email: string | undefined;
-  email_confirmed_at: string | undefined;
-  id: any;
-  last_sign_in_at: string | undefined;
-}[];
+export type IAdminListUsersResponse = Database['public']['Functions']['get_non_anonymous_users']['Returns'];
 
 export type IAdminListUserRolesResponse = Database['public']['Tables']['user_roles']['Row'][];

--- a/apps/picsa-server/supabase/migrations/20260721130000_get_non_anonymous_users_profiles.sql
+++ b/apps/picsa-server/supabase/migrations/20260721130000_get_non_anonymous_users_profiles.sql
@@ -11,6 +11,7 @@ returns table (
 )
 language sql
 security definer
+set search_path = ''
 as $$
   select
     u.id,

--- a/apps/picsa-server/supabase/migrations/20260721130000_get_non_anonymous_users_profiles.sql
+++ b/apps/picsa-server/supabase/migrations/20260721130000_get_non_anonymous_users_profiles.sql
@@ -1,0 +1,31 @@
+drop function if exists public.get_non_anonymous_users();
+
+create function public.get_non_anonymous_users()
+returns table (
+  id uuid,
+  email text,
+  email_confirmed_at timestamp with time zone,
+  last_sign_in_at timestamp with time zone,
+  full_name text,
+  organisation text
+)
+language sql
+security definer
+as $$
+  select
+    u.id,
+    u.email,
+    u.email_confirmed_at,
+    u.last_sign_in_at,
+    coalesce(p.full_name, u.raw_user_meta_data->>'full_name') as full_name,
+    coalesce(p.organisation, u.raw_user_meta_data->>'organisation') as organisation
+  from auth.users u
+  left join public.user_profiles p on u.id = p.user_id
+  where u.is_anonymous = false;
+$$;
+
+-- Revoke execute from everyone
+revoke all on function public.get_non_anonymous_users() from public;
+
+-- Explicitly grant only to service_role
+grant execute on function public.get_non_anonymous_users() to service_role;

--- a/apps/picsa-server/supabase/types/db.types.ts
+++ b/apps/picsa-server/supabase/types/db.types.ts
@@ -1142,8 +1142,10 @@ export type Database = {
         Returns: {
           email: string;
           email_confirmed_at: string;
+          full_name: string;
           id: string;
           last_sign_in_at: string;
+          organisation: string;
         }[];
       };
       user_has_role: {


### PR DESCRIPTION
## Developer Summary

> Info for reviewer, e.g. use of ai, pain points/challenges, discussion points for monthly dev call

## Related Issues

> Link any related issues (e.g., `Closes #[issue_number]`, `Relates to #[issue_number]`)

## Screenshots / Videos
**Screenshot** - Permissions screen now includes user name and organisation (previously only email)
<img width="2560" height="1440" alt="localhost_4200_home(720p)" src="https://github.com/user-attachments/assets/eb1c6811-769a-45e5-9d2d-696dae55678a" />

---

## AI Summary

> Will be generated on PR open. Regenerate by typing comment `/describe` in PR
> More info at https://docs.pr-agent.ai/tools/describe/

### Description

### 🤖 Generated by PR Agent at b66bc559c9599a80e8b3049cd3fc6bdd7f56f2a2

- Add `user` column to permission tables
- Display user name and organisation details
- Update DB function to return profile data
- Reuse generated `db.types` type definition


### Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user-permissions.component.ts</strong><dd><code>Switch permission tables to user column</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-apps/dashboard/src/app/modules/deployment/pages/user-permissions/user-permissions.component.ts

<ul><li>Replaced <code>email</code> column with <code>user</code> column in three table option configs<br> <li> Added <code>full_name</code> and <code>organisation</code> to <code>pendingRequestsDetails</code> derived <br>data</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/655/files#diff-ca5f2d1b22d1976d63fc69e123831b0ae18254abb51344fe9285bbf2d8b3e081">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Use generated DB type for user list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-server/supabase/functions/dashboard/admin/types.ts

<ul><li>Replaced custom <code>IAdminListUsersResponse</code> type with the generated <br><code>db.types</code> return type<br> <li> Removed now-unused inline type definition</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/655/files#diff-c03be2444adba7bfd4d5a5c2158d578722903bce47cb6ca7d28b9dd145b96382">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>db.types.ts</strong><dd><code>Update generated DB types for new columns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-server/supabase/types/db.types.ts

<ul><li>Added <code>full_name</code> and <code>organisation</code> fields to <code>get_non_anonymous_users</code> <br>return type<br> <li> Kept in sync with updated SQL function definition</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/655/files#diff-9b3b2ea15bcdca4f9278a4dd3fda22494391a21e2bc05e3e685fc5d254d9de0f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>user-permissions.component.html</strong><dd><code>Add user template to permission tables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-apps/dashboard/src/app/modules/deployment/pages/user-permissions/user-permissions.component.html

<ul><li>Added new <code>userTemplate</code> ng-template rendering name, email and <br>organisation<br> <li> Wired template into <code>user</code> column for all three tables</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/655/files#diff-fb38934e3afaa33c00a50d0934d70026ba017d9f4838187b9533800fc7335eaa">+23/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>20260721130000_get_non_anonymous_users_profiles.sql</strong><dd><code>Extend SQL function with profile data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-server/supabase/migrations/20260721130000_get_non_anonymous_users_profiles.sql

<ul><li>Recreated <code>get_non_anonymous_users</code> to join <code>user_profiles</code> and include <br><code>full_name</code> and <code>organisation</code><br> <li> Restricted execution to <code>service_role</code> only</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/655/files#diff-bb81ae9fbb19592ff31ae36b281711db61868530ca96114fdc08284759086ee4">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

### Diagram


```mermaid
flowchart LR
  DB["get_non_anonymous_users()"] -- "full_name, organisation" --> Types["db.types.ts"]
  Types --> EdgeFn["Edge Function Types"]
  EdgeFn --> Dashboard["User Permissions Component"]
  Dashboard -- "userTemplate" --> Tables["Permissions Tables"]
```

#