### PR TITLE
fix(dashboard): live query cache

### DIFF
--- a/libs/shared/src/services/core/supabase/utils/query.utils.spec.ts
+++ b/libs/shared/src/services/core/supabase/utils/query.utils.spec.ts
@@ -1,0 +1,108 @@
+import { Injector } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Database } from '@picsa/server-types';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+import { tableWithLive } from './query.utils';
+
+describe('query.utils', () => {
+  let mockSupabaseClient: jest.Mocked<SupabaseClient<Database>>;
+  let mockChannel: any;
+  let mockQueryBuilder: any;
+  let injector: Injector;
+
+  beforeEach(() => {
+    mockChannel = {
+      on: jest.fn().mockReturnThis(),
+      subscribe: jest.fn().mockReturnThis(),
+    };
+
+    mockQueryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      then: jest.fn((resolve) => resolve({ data: [{ id: '1', status: 'pending' }], error: null })),
+    };
+
+    mockSupabaseClient = {
+      from: jest.fn().mockReturnValue(mockQueryBuilder),
+      channel: jest.fn().mockReturnValue(mockChannel),
+      removeChannel: jest.fn(),
+    } as any;
+
+    TestBed.configureTestingModule({
+      providers: [Injector],
+    });
+    injector = TestBed.inject(Injector);
+  });
+
+  describe('liveQuery$ caching', () => {
+    it('returns the same cached Observable instance for identical query parameters while subscribed', () => {
+      const table = tableWithLive(injector, mockSupabaseClient, 'deployment_access_requests');
+
+      const query1$ = table.liveQuery$({ filter: { status: 'pending' } });
+      const query2$ = table.liveQuery$({ filter: { status: 'pending' } });
+
+      const sub1 = query1$.subscribe();
+      const query3$ = table.liveQuery$({ filter: { status: 'pending' } });
+
+      expect(query1$).toBe(query3$);
+      expect(query2$).toBe(query3$);
+
+      sub1.unsubscribe();
+    });
+
+    it('serializes array/object filter values with JSON.stringify to avoid [object Object] collisions', () => {
+      const table = tableWithLive(injector, mockSupabaseClient, 'deployment_access_requests');
+
+      const queryA$ = table.liveQuery$({ filter: { status: { eq: 'pending' } as any } });
+      const queryB$ = table.liveQuery$({ filter: { status: { eq: 'approved' } as any } });
+
+      const subA = queryA$.subscribe();
+
+      expect(queryA$).not.toBe(queryB$);
+
+      subA.unsubscribe();
+    });
+
+    it('evicts the cache key when all subscribers unsubscribe', () => {
+      const table = tableWithLive(injector, mockSupabaseClient, 'deployment_access_requests');
+
+      const query1$ = table.liveQuery$({ filter: { status: 'pending' } });
+      const sub1 = query1$.subscribe();
+
+      // Active subscription keeps query in cache
+      expect(table.liveQuery$({ filter: { status: 'pending' } })).toBe(query1$);
+
+      sub1.unsubscribe();
+
+      // After refCount drops to 0, cache key is evicted
+      const query2$ = table.liveQuery$({ filter: { status: 'pending' } });
+      expect(query2$).not.toBe(query1$);
+    });
+
+    it('does not evict a new active cache entry when an old instance finalizes later', () => {
+      const table = tableWithLive(injector, mockSupabaseClient, 'deployment_access_requests');
+
+      // Create query1$ and subscribe
+      const query1$ = table.liveQuery$({ filter: { status: 'pending' } });
+      const sub1 = query1$.subscribe();
+
+      // Unsubscribe query1$ -> evicts query1$ from cache
+      sub1.unsubscribe();
+
+      // Create query2$ and subscribe -> stores query2$ in cache
+      const query2$ = table.liveQuery$({ filter: { status: 'pending' } });
+      const sub2 = query2$.subscribe();
+
+      // Re-subscribe to query1$ and unsubscribe it again (simulating retained instance teardown)
+      const sub1Again = query1$.subscribe();
+      sub1Again.unsubscribe();
+
+      // The cache should STILL hold query2$ because query1$'s finalize ignored the eviction
+      expect(table.liveQuery$({ filter: { status: 'pending' } })).toBe(query2$);
+
+      sub2.unsubscribe();
+    });
+  });
+});

--- a/libs/shared/src/services/core/supabase/utils/query.utils.spec.ts
+++ b/libs/shared/src/services/core/supabase/utils/query.utils.spec.ts
@@ -104,5 +104,25 @@ describe('query.utils', () => {
 
       sub2.unsubscribe();
     });
+
+    it('isolates query caches per SupabaseClient instance', () => {
+      const secondMockClient: jest.Mocked<SupabaseClient<Database>> = {
+        from: jest.fn().mockReturnValue({ ...mockQueryBuilder }),
+        channel: jest.fn().mockReturnValue(mockChannel),
+        removeChannel: jest.fn(),
+      } as any;
+
+      const table1 = tableWithLive(injector, mockSupabaseClient, 'deployment_access_requests');
+      const table2 = tableWithLive(injector, secondMockClient, 'deployment_access_requests');
+
+      const query1$ = table1.liveQuery$({ filter: { status: 'pending' } });
+      const query2$ = table2.liveQuery$({ filter: { status: 'pending' } });
+
+      const sub1 = query1$.subscribe();
+
+      expect(query1$).not.toBe(query2$);
+
+      sub1.unsubscribe();
+    });
   });
 });

--- a/libs/shared/src/services/core/supabase/utils/query.utils.ts
+++ b/libs/shared/src/services/core/supabase/utils/query.utils.ts
@@ -35,12 +35,13 @@ type MaybeSignal<T> = T | Signal<T>;
 
 const liveQueryCache = new Map<string, Observable<any>>();
 
+/** Generate a deterministic cache key for query options. Use JSON.stringify to avoid object/array `[object Object]` collisions. */
 function getLiveQueryCacheKey(tableName: string, opts: LiveQueryOpts<any>): string {
   const filterStr = opts.filter
     ? Object.entries(opts.filter)
         .filter(([, v]) => v !== undefined)
         .sort(([a], [b]) => a.localeCompare(b))
-        .map(([k, v]) => `${k}=${v}`)
+        .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
         .join('&')
     : '';
   const orderByStr = opts.orderBy ? `${String(opts.orderBy.column)}:${opts.orderBy.ascending ?? true}` : '';
@@ -57,6 +58,8 @@ function liveQuery$<T extends Record<string, any>>(
   opts: LiveQueryOpts<T> = {},
 ): Observable<T[]> {
   const cacheKey = getLiveQueryCacheKey(tableName as string, opts);
+
+  // Return active shared observable if a query with identical parameters is already in flight
   if (liveQueryCache.has(cacheKey)) {
     return liveQueryCache.get(cacheKey)!;
   }
@@ -113,9 +116,13 @@ function liveQuery$<T extends Record<string, any>>(
           : state;
       return state;
     }, []),
+    // Evict cache key when refCount drops to 0, but only if the cache entry still points to this instance
     finalize(() => {
-      liveQueryCache.delete(cacheKey);
+      if (liveQueryCache.get(cacheKey) === query$) {
+        liveQueryCache.delete(cacheKey);
+      }
     }),
+    // Multicast with refCount: true to teardown realtime channel when all subscribers disconnect
     shareReplay({ bufferSize: 1, refCount: true }),
   );
 

--- a/libs/shared/src/services/core/supabase/utils/query.utils.ts
+++ b/libs/shared/src/services/core/supabase/utils/query.utils.ts
@@ -31,9 +31,17 @@ type Tables = Database['public']['Tables'];
 type TableRow<T extends keyof Tables> = Tables[T]['Row'];
 type MaybeSignal<T> = T | Signal<T>;
 
-/* --- caching: share live queries with identical parameters --- */
+/* --- caching: share live queries per SupabaseClient instance --- */
+const clientQueryCaches = new WeakMap<SupabaseClient<any>, Map<string, Observable<any>>>();
 
-const liveQueryCache = new Map<string, Observable<any>>();
+function getClientLiveQueryCache(client: SupabaseClient<any>): Map<string, Observable<any>> {
+  let cache = clientQueryCaches.get(client);
+  if (!cache) {
+    cache = new Map<string, Observable<any>>();
+    clientQueryCaches.set(client, cache);
+  }
+  return cache;
+}
 
 /** Generate a deterministic cache key for query options. Use JSON.stringify to avoid object/array `[object Object]` collisions. */
 function getLiveQueryCacheKey(tableName: string, opts: LiveQueryOpts<any>): string {
@@ -57,9 +65,10 @@ function liveQuery$<T extends Record<string, any>>(
   tableName: keyof Database['public']['Tables'],
   opts: LiveQueryOpts<T> = {},
 ): Observable<T[]> {
+  const liveQueryCache = getClientLiveQueryCache(supabase as SupabaseClient<any>);
   const cacheKey = getLiveQueryCacheKey(tableName as string, opts);
 
-  // Return active shared observable if a query with identical parameters is already in flight
+  // Return active shared observable if a query with identical parameters is already in flight for this client
   if (liveQueryCache.has(cacheKey)) {
     return liveQueryCache.get(cacheKey)!;
   }

--- a/libs/shared/src/services/core/supabase/utils/query.utils.ts
+++ b/libs/shared/src/services/core/supabase/utils/query.utils.ts
@@ -2,7 +2,18 @@ import { effect, Injector, isSignal, runInInjectionContext, Signal } from '@angu
 import { toSignal } from '@angular/core/rxjs-interop';
 import { Database } from '@picsa/server-types';
 import { SupabaseClient } from '@supabase/supabase-js';
-import { defer, map, merge, Observable, scan, shareReplay, Subject, switchMap } from 'rxjs';
+import {
+  defer,
+  distinctUntilChanged,
+  finalize,
+  map,
+  merge,
+  Observable,
+  scan,
+  shareReplay,
+  Subject,
+  switchMap,
+} from 'rxjs';
 
 /* --- types --- */
 
@@ -20,6 +31,24 @@ type Tables = Database['public']['Tables'];
 type TableRow<T extends keyof Tables> = Tables[T]['Row'];
 type MaybeSignal<T> = T | Signal<T>;
 
+/* --- caching: share live queries with identical parameters --- */
+
+const liveQueryCache = new Map<string, Observable<any>>();
+
+function getLiveQueryCacheKey(tableName: string, opts: LiveQueryOpts<any>): string {
+  const filterStr = opts.filter
+    ? Object.entries(opts.filter)
+        .filter(([, v]) => v !== undefined)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => `${k}=${v}`)
+        .join('&')
+    : '';
+  const orderByStr = opts.orderBy ? `${String(opts.orderBy.column)}:${opts.orderBy.ascending ?? true}` : '';
+  return [tableName, filterStr, opts.select ?? '*', opts.schema ?? 'public', opts.primaryKey ?? 'id', orderByStr].join(
+    '|',
+  );
+}
+
 /* --- core: Observable-based live query --- */
 
 function liveQuery$<T extends Record<string, any>>(
@@ -27,6 +56,11 @@ function liveQuery$<T extends Record<string, any>>(
   tableName: keyof Database['public']['Tables'],
   opts: LiveQueryOpts<T> = {},
 ): Observable<T[]> {
+  const cacheKey = getLiveQueryCacheKey(tableName as string, opts);
+  if (liveQueryCache.has(cacheKey)) {
+    return liveQueryCache.get(cacheKey)!;
+  }
+
   const { filter = {}, orderBy, primaryKey = 'id' as keyof T & string, select, schema = 'public' } = opts;
 
   const init$ = defer(async () => {
@@ -65,7 +99,7 @@ function liveQuery$<T extends Record<string, any>>(
     return () => supabase.removeChannel(ch);
   });
 
-  return merge(init$, changes$).pipe(
+  const query$ = merge(init$, changes$).pipe(
     scan<Change<T>, T[]>((state, ev) => {
       if (ev.type === 'init') return ev.rows;
       if (ev.type === 'insert') return ev.new ? [ev.new, ...state] : state;
@@ -79,8 +113,14 @@ function liveQuery$<T extends Record<string, any>>(
           : state;
       return state;
     }, []),
+    finalize(() => {
+      liveQueryCache.delete(cacheKey);
+    }),
     shareReplay({ bufferSize: 1, refCount: true }),
   );
+
+  liveQueryCache.set(cacheKey, query$);
+  return query$;
 }
 
 /* --- table wrapper: adds liveQuery$ and liveSignal with MaybeSignals --- */
@@ -162,6 +202,7 @@ export function tableWithLive<T extends keyof Tables>(injector: Injector, client
       );
 
       const rows$ = params$.pipe(
+        distinctUntilChanged((prev, curr) => JSON.stringify(prev) === JSON.stringify(curr)),
         map((p) => ({
           opts: {
             filter: p.filter,


### PR DESCRIPTION
## Developer Summary

> Info for reviewer, e.g. use of ai, pain points/challenges, discussion points for monthly dev call

## Related Issues

> Link any related issues (e.g., `Closes #[issue_number]`, `Relates to #[issue_number]`)

## Screenshots / Videos

> Include at least 1-2 screenshots of videos if visual changes

---

## AI Summary

> Will be generated on PR open. Regenerate by typing comment `/describe` in PR
> More info at https://docs.pr-agent.ai/tools/describe/

### Description

### 🤖 Generated by PR Agent at 9a1329d3cbadbf4eb1d1a0e1dc34cfc68d0f6957

- Add shared live-query cache keyed by table/filter/select/schema/orderBy
- Reuse cached Observable via shareReplay and `finalize` eviction
- Deduplicate `params$` emissions with `distinctUntilChanged` JSON compare


### Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>query.utils.ts</strong><dd><code>Cache and deduplicate live query observables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/shared/src/services/core/supabase/utils/query.utils.ts

<ul><li>Added module-level <code>liveQueryCache</code> Map keyed by <br>table/filter/select/schema/orderBy<br> <li> Cache-hit path returns existing observable; new entries register <br><code>finalize</code> to evict on teardown<br> <li> Added <code>distinctUntilChanged</code> on <code>params$</code> to skip no-op parameter <br>emissions</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/658/files#diff-d1a2b03e8f39d8a5d805aa2029dac9cdd86924fc04f7bd04bf4540ee6cb03e2b">+43/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

### Diagram


```mermaid
flowchart LR
  A["params$ input"] --> B["distinctUntilChanged"]
  B --> C["liveQuery$ factory"]
  C --> D{"cacheKey exists?"}
  D -- "yes" --> E["return cached Observable"]
  D -- "no" --> F["build query$"]
  F --> G["shareReplay + finalize"]
  G --> H["store in liveQueryCache"]
  H --> E
```

#