### PR TITLE
feat(dashboard): collapsible sidebar

### DIFF
--- a/apps/picsa-apps/dashboard/src/app/layout/authenticated-layout/authenticated-layout.component.spec.ts
+++ b/apps/picsa-apps/dashboard/src/app/layout/authenticated-layout/authenticated-layout.component.spec.ts
@@ -1,0 +1,96 @@
+import { provideHttpClient } from '@angular/common/http';
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { SupabaseAuthService } from '@picsa/shared/services/core/supabase/services/supabase-auth.service';
+
+import { DeploymentDashboardService } from '../../modules/deployment/deployment.service';
+import { AuthenticatedLayoutComponent, SIDEBAR_COLLAPSED_KEY } from './authenticated-layout';
+
+describe('AuthenticatedLayoutComponent', () => {
+  let component: AuthenticatedLayoutComponent;
+  let fixture: ComponentFixture<AuthenticatedLayoutComponent>;
+
+  const mockSupabaseAuthService = {
+    signInDashboardDevUser: jest.fn().mockResolvedValue(null),
+    authUser: signal(null),
+    isAuthChecked: signal(true),
+  };
+
+  const mockDeploymentService = {
+    activeDeployment: signal(null),
+    userDeployments: signal([]),
+    allDeployments: signal([]),
+    pendingRequests: signal([]),
+    isDeploymentChecked: signal(true),
+  };
+
+  beforeEach(async () => {
+    localStorage.removeItem(SIDEBAR_COLLAPSED_KEY);
+
+    await TestBed.configureTestingModule({
+      imports: [AuthenticatedLayoutComponent, NoopAnimationsModule],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        { provide: SupabaseAuthService, useValue: mockSupabaseAuthService },
+        { provide: DeploymentDashboardService, useValue: mockDeploymentService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AuthenticatedLayoutComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    localStorage.removeItem(SIDEBAR_COLLAPSED_KEY);
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should default to expanded state when localStorage is clear', () => {
+    expect(component.isCollapsed()).toBe(false);
+  });
+
+  it('should toggle collapse state and persist to localStorage', () => {
+    expect(component.isCollapsed()).toBe(false);
+
+    component.toggleSidebar();
+    expect(component.isCollapsed()).toBe(true);
+    expect(localStorage.getItem(SIDEBAR_COLLAPSED_KEY)).toBe('true');
+
+    component.toggleSidebar();
+    expect(component.isCollapsed()).toBe(false);
+    expect(localStorage.getItem(SIDEBAR_COLLAPSED_KEY)).toBe('false');
+  });
+
+  it('should apply .is-collapsed class to mat-sidenav when collapsed', () => {
+    component.toggleSidebar();
+    fixture.detectChanges();
+
+    const sidenavEl = fixture.nativeElement.querySelector('mat-sidenav');
+    expect(sidenavEl.classList.contains('is-collapsed')).toBe(true);
+  });
+
+  it('should expand on hover when collapsed and reset on mouse leave', () => {
+    component.toggleSidebar(); // collapse
+    expect(component.isCollapsed()).toBe(true);
+    expect(component.isEffectiveExpanded()).toBe(false);
+
+    component.onMouseEnter();
+    expect(component.isHovered()).toBe(true);
+    expect(component.isEffectiveExpanded()).toBe(true);
+
+    fixture.detectChanges();
+    const sidenavEl = fixture.nativeElement.querySelector('mat-sidenav');
+    expect(sidenavEl.classList.contains('is-hovered')).toBe(true);
+
+    component.onMouseLeave();
+    expect(component.isHovered()).toBe(false);
+    expect(component.isEffectiveExpanded()).toBe(false);
+  });
+});

--- a/apps/picsa-apps/dashboard/src/app/layout/authenticated-layout/authenticated-layout.html
+++ b/apps/picsa-apps/dashboard/src/app/layout/authenticated-layout/authenticated-layout.html
@@ -1,31 +1,52 @@
-<mat-toolbar color="primary" class="mat-elevation-z2 flex items-center">
+<mat-toolbar color="primary" class="mat-elevation-z2 flex items-center gap-2">
+  <button
+    matIconButton
+    (click)="toggleSidebar()"
+    [matTooltip]="isCollapsed() ? 'Expand sidebar' : 'Collapse sidebar'"
+    aria-label="Toggle sidebar"
+  >
+    <mat-icon>{{ isCollapsed() ? 'menu' : 'menu_open' }}</mat-icon>
+  </button>
   <dashboard-deployment-select />
   <dashboard-profile-menu class="ml-auto" />
 </mat-toolbar>
 <mat-sidenav-container style="flex: 1">
   <!-- Sidenav -->
-  <mat-sidenav #sidenav mode="side" opened [fixedInViewport]="true" fixedTopGap="64">
-    <mat-nav-list class="w-48 lg:w-64 flex-1">
+  <mat-sidenav
+    #sidenav
+    mode="side"
+    opened
+    [fixedInViewport]="true"
+    fixedTopGap="64"
+    [class.is-collapsed]="isCollapsed()"
+    [class.is-hovered]="isCollapsed() && isHovered()"
+    (mouseenter)="onMouseEnter()"
+    (mouseleave)="onMouseLeave()"
+  >
+    <mat-nav-list [class]="isEffectiveExpanded() ? 'w-48 lg:w-64 flex-1' : 'w-16 flex-1'">
       @for (link of navLinks; track link.href) { @if (link.children) {
       <!-- Nested nav items -->
       <mat-expansion-panel
         class="mat-elevation-z0"
         hideToggle
-        [expanded]="rla.isActive"
+        [expanded]="isEffectiveExpanded() && rla.isActive"
+        [disabled]="!isEffectiveExpanded()"
         *roleRequired="link.roleRequired"
       >
         <mat-expansion-panel-header
           style="padding: 0 16px"
           [routerLink]="link.href"
-          routerLinkActive
+          routerLinkActive="mdc-list-item--activated active-link"
           #rla="routerLinkActive"
           [routerLinkActiveOptions]="{ exact: false }"
+          [matTooltip]="!isEffectiveExpanded() ? link.label : ''"
+          matTooltipPosition="right"
         >
           <mat-panel-title>
             <ng-container *ngTemplateOutlet="linkTemplate; context: { $implicit: link }"></ng-container>
           </mat-panel-title>
         </mat-expansion-panel-header>
-        @for (child of link.children || []; track $index) {
+        @if (isEffectiveExpanded()) { @for (child of link.children || []; track $index) {
         <a
           mat-list-item
           [routerLink]="child.href"
@@ -34,7 +55,7 @@
         >
           <ng-container *ngTemplateOutlet="linkTemplate; context: { $implicit: child }"></ng-container>
         </a>
-        }
+        } }
       </mat-expansion-panel>
       } @else {
       <!-- Single nav item -->
@@ -43,12 +64,14 @@
         [routerLink]="link.href"
         routerLinkActive="mdc-list-item--activated active-link"
         *roleRequired="link.roleRequired"
+        [matTooltip]="!isEffectiveExpanded() ? link.label : ''"
+        matTooltipPosition="right"
       >
         <ng-container *ngTemplateOutlet="linkTemplate; context: { $implicit: link }"></ng-container>
       </a>
       } }
     </mat-nav-list>
-    <mat-nav-list class="w-48 lg:w-64 mt-auto">
+    <mat-nav-list [class]="isEffectiveExpanded() ? 'w-48 lg:w-64 mt-auto' : 'w-16 mt-auto'">
       <mat-divider></mat-divider>
       <div mat-subheader></div>
       <mat-divider></mat-divider>
@@ -58,13 +81,17 @@
         [routerLink]="link.href"
         routerLinkActive="mdc-list-item--activated active-link"
         *roleRequired="link.roleRequired"
+        [matTooltip]="!isEffectiveExpanded() ? link.label : ''"
+        matTooltipPosition="right"
       >
         <ng-container *ngTemplateOutlet="linkTemplate; context: { $implicit: link }"></ng-container>
       </a>
       }
     </mat-nav-list>
+    @if (isEffectiveExpanded()) {
     <mat-divider></mat-divider>
     <dashboard-footer [isSidebar]="true" class="w-48 lg:w-64" />
+    }
   </mat-sidenav>
   <!-- Main Content -->
   <mat-sidenav-content>
@@ -75,12 +102,13 @@
 </mat-sidenav-container>
 
 <ng-template #linkTemplate let-link>
-  <div class="nav-item">
+  <div class="nav-item flex items-center" [class.justify-center]="!isEffectiveExpanded()">
     @if (link.matIcon) {
-    <mat-icon style="margin-right: 8px">{{ link.matIcon }}</mat-icon>
-    } @else {
+    <mat-icon [style.margin-right]="isEffectiveExpanded() ? '8px' : '0'">{{ link.matIcon }}</mat-icon>
+    } @else { @if (isEffectiveExpanded()) {
     <span style="width: 32px"></span>
-    }
+    } } @if (isEffectiveExpanded()) {
     <span class="link-label">{{ link.label }}</span>
+    }
   </div>
 </ng-template>

--- a/apps/picsa-apps/dashboard/src/app/layout/authenticated-layout/authenticated-layout.html
+++ b/apps/picsa-apps/dashboard/src/app/layout/authenticated-layout/authenticated-layout.html
@@ -23,7 +23,7 @@
     (mouseenter)="onMouseEnter()"
     (mouseleave)="onMouseLeave()"
   >
-    <mat-nav-list [class]="isEffectiveExpanded() ? 'w-48 lg:w-64 flex-1' : 'w-16 flex-1'">
+    <mat-nav-list class="w-full flex-1">
       @for (link of navLinks; track link.href) { @if (link.children) {
       <!-- Nested nav items -->
       <mat-expansion-panel
@@ -35,6 +35,7 @@
       >
         <mat-expansion-panel-header
           style="padding: 0 16px"
+          class="parent-link"
           [routerLink]="link.href"
           routerLinkActive="mdc-list-item--activated active-link"
           #rla="routerLinkActive"
@@ -49,11 +50,12 @@
         @if (isEffectiveExpanded()) { @for (child of link.children || []; track $index) {
         <a
           mat-list-item
+          class="child-link"
           [routerLink]="child.href"
           routerLinkActive="mdc-list-item--activated active-link"
           *roleRequired="child.roleRequired"
         >
-          <ng-container *ngTemplateOutlet="linkTemplate; context: { $implicit: child }"></ng-container>
+          <ng-container *ngTemplateOutlet="linkTemplate; context: { $implicit: child, isChild: true }"></ng-container>
         </a>
         } }
       </mat-expansion-panel>
@@ -61,6 +63,7 @@
       <!-- Single nav item -->
       <a
         mat-list-item
+        class="parent-link"
         [routerLink]="link.href"
         routerLinkActive="mdc-list-item--activated active-link"
         *roleRequired="link.roleRequired"
@@ -71,13 +74,14 @@
       </a>
       } }
     </mat-nav-list>
-    <mat-nav-list [class]="isEffectiveExpanded() ? 'w-48 lg:w-64 mt-auto' : 'w-16 mt-auto'">
+    <mat-nav-list class="w-full mt-auto">
       <mat-divider></mat-divider>
       <div mat-subheader></div>
       <mat-divider></mat-divider>
       @for (link of adminLinks; track link.href) {
       <a
         mat-list-item
+        class="parent-link"
         [routerLink]="link.href"
         routerLinkActive="mdc-list-item--activated active-link"
         *roleRequired="link.roleRequired"
@@ -90,7 +94,7 @@
     </mat-nav-list>
     @if (isEffectiveExpanded()) {
     <mat-divider></mat-divider>
-    <dashboard-footer [isSidebar]="true" class="w-48 lg:w-64" />
+    <dashboard-footer [isSidebar]="true" />
     }
   </mat-sidenav>
   <!-- Main Content -->
@@ -101,11 +105,11 @@
   </mat-sidenav-content>
 </mat-sidenav-container>
 
-<ng-template #linkTemplate let-link>
-  <div class="nav-item flex items-center" [class.justify-center]="!isEffectiveExpanded()">
+<ng-template #linkTemplate let-link let-isChild="isChild">
+  <div class="nav-item flex items-center" [class.pl-6]="isChild">
     @if (link.matIcon) {
-    <mat-icon [style.margin-right]="isEffectiveExpanded() ? '8px' : '0'">{{ link.matIcon }}</mat-icon>
-    } @else { @if (isEffectiveExpanded()) {
+    <mat-icon style="margin-right: 8px">{{ link.matIcon }}</mat-icon>
+    } @else { @if (isEffectiveExpanded() && !isChild) {
     <span style="width: 32px"></span>
     } } @if (isEffectiveExpanded()) {
     <span class="link-label">{{ link.label }}</span>

--- a/apps/picsa-apps/dashboard/src/app/layout/authenticated-layout/authenticated-layout.scss
+++ b/apps/picsa-apps/dashboard/src/app/layout/authenticated-layout/authenticated-layout.scss
@@ -16,24 +16,46 @@ mat-sidenav-content {
   line-height: 24px;
   font-weight: 500;
 }
-::ng-deep .mat-expansion-panel-body {
-  padding: 0 0 16px 0;
-}
 
-::ng-deep {
-  mat-expansion-panel-header.active-link,
-  .mat-expansion-panel-header.mdc-list-item--activated,
-  a.active-link {
-    background-color: rgba(25, 118, 210, 0.08) !important;
+mat-sidenav {
+  --mat-sidenav-container-width: 204px;
+  // Inactive state - lighter gray consistency across all links, headers, and icons
+  .nav-item,
+  .mat-icon,
+  .link-label {
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+  }
 
-    .mat-panel-title,
-    .link-label,
-    mat-icon {
-      color: var(--mat-sys-primary, var(--mdc-theme-primary, #1976d2)) !important;
+  ::ng-deep {
+    .mat-expansion-panel-body {
+      padding: 0 !important;
+    }
+
+    // Active parent links get background tint + primary color
+    .parent-link.active-link,
+    .parent-link.mdc-list-item--activated {
+      background-color: rgba(25, 118, 210, 0.08) !important;
+    }
+
+    // Active child links get text/icon primary color ONLY (no background tint)
+    .child-link.active-link,
+    .child-link.mdc-list-item--activated {
+      background-color: transparent !important;
+    }
+
+    // Primary text/icon color for all active items
+    .active-link,
+    .mdc-list-item--activated {
+      .nav-item,
+      .mat-panel-title,
+      .link-label,
+      mat-icon {
+        color: var(--mat-sys-primary, var(--mdc-theme-primary, #1976d2)) !important;
+      }
     }
   }
 }
-
+// Collapsed State
 mat-sidenav.is-collapsed {
   width: 64px !important;
   transition:
@@ -51,7 +73,7 @@ mat-sidenav.is-collapsed {
   }
 
   &.is-hovered {
-    width: 256px !important;
+    width: var(--mat-sidenav-container-width) !important;
     z-index: 20;
     box-shadow: 4px 0 16px rgba(0, 0, 0, 0.12);
   }

--- a/apps/picsa-apps/dashboard/src/app/layout/authenticated-layout/authenticated-layout.scss
+++ b/apps/picsa-apps/dashboard/src/app/layout/authenticated-layout/authenticated-layout.scss
@@ -4,6 +4,7 @@
 
 mat-sidenav-content {
   @apply flex flex-col;
+  transition: margin-left 0.2s ease-in-out;
 }
 
 .nav-item {
@@ -17,4 +18,47 @@ mat-sidenav-content {
 }
 ::ng-deep .mat-expansion-panel-body {
   padding: 0 0 16px 0;
+}
+
+::ng-deep {
+  mat-expansion-panel-header.active-link,
+  .mat-expansion-panel-header.mdc-list-item--activated,
+  a.active-link {
+    background-color: rgba(25, 118, 210, 0.08) !important;
+
+    .mat-panel-title,
+    .link-label,
+    mat-icon {
+      color: var(--mat-sys-primary, var(--mdc-theme-primary, #1976d2)) !important;
+    }
+  }
+}
+
+mat-sidenav.is-collapsed {
+  width: 64px !important;
+  transition:
+    width 0.2s ease-in-out,
+    box-shadow 0.2s ease-in-out;
+
+  ::ng-deep {
+    .mat-expansion-panel-header {
+      padding: 0 12px !important;
+    }
+    .mdc-list-item {
+      padding-left: 12px !important;
+      padding-right: 12px !important;
+    }
+  }
+
+  &.is-hovered {
+    width: 256px !important;
+    z-index: 20;
+    box-shadow: 4px 0 16px rgba(0, 0, 0, 0.12);
+  }
+}
+
+mat-sidenav-container:has(mat-sidenav.is-collapsed) {
+  mat-sidenav-content {
+    margin-left: 64px !important;
+  }
 }

--- a/apps/picsa-apps/dashboard/src/app/layout/authenticated-layout/authenticated-layout.ts
+++ b/apps/picsa-apps/dashboard/src/app/layout/authenticated-layout/authenticated-layout.ts
@@ -1,5 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { RouterModule } from '@angular/router';
 import { APP_VERSION } from '@picsa/environments/src/version';
@@ -10,6 +10,16 @@ import { AuthRoleRequiredDirective } from '../../modules/auth';
 import { DeploymentSelectComponent } from '../../modules/deployment/components';
 import { ProfileMenuComponent } from '../../modules/profile/components/profile-menu/profile-menu.component';
 import { DashboardFooterComponent } from '../footer/footer.component';
+
+export const SIDEBAR_COLLAPSED_KEY = 'picsa_dashboard_sidebar_collapsed';
+
+const getInitialCollapsedState = (): boolean => {
+  try {
+    return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};
 
 @Component({
   imports: [
@@ -31,4 +41,33 @@ export class AuthenticatedLayoutComponent {
   navLinks = DASHBOARD_NAV_LINKS;
   adminLinks = ADMIN_NAV_LINKS;
   appVersion = APP_VERSION;
+
+  isCollapsed = signal<boolean>(getInitialCollapsedState());
+  isHovered = signal<boolean>(false);
+
+  isEffectiveExpanded = computed(() => !this.isCollapsed() || this.isHovered());
+
+  toggleSidebar() {
+    this.isCollapsed.update((collapsed) => {
+      const next = !collapsed;
+      try {
+        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(next));
+      } catch {
+        // ignore storage errors
+      }
+      return next;
+    });
+  }
+
+  onMouseEnter() {
+    if (this.isCollapsed()) {
+      this.isHovered.set(true);
+    }
+  }
+
+  onMouseLeave() {
+    if (this.isCollapsed()) {
+      this.isHovered.set(false);
+    }
+  }
 }

--- a/libs/theme/src/_overrides.scss
+++ b/libs/theme/src/_overrides.scss
@@ -100,6 +100,12 @@ div.mdc-dialog__actions {
   display: flex;
   flex-direction: column;
 }
+// Remove scrollbars from collapsed sidebar
+mat-sidenav-container:has(mat-sidenav.is-collapsed) {
+  .mat-drawer-inner-container {
+    overflow-x: hidden !important;
+  }
+}
 // Increase size and set primary colour for text inputs
 input.mat-mdc-input-element.mdc-text-field__input {
   font-size: 30px;


### PR DESCRIPTION
## Developer Summary

Add support for collapsible sidebar, improving available space on smaller screens

## Screenshots / Videos
**Screenshot** - sidebar in collapsed mode provides more space on smaller devices
<img width="1920" height="1200" alt="localhost_4200_translations_list(picsa)" src="https://github.com/user-attachments/assets/0ebed421-3448-4f9c-ad59-0f0014136df3" />

**Screenshot** - collapsed sidebar can still be hovered to show full text as an overlay (without shifting content)
<img width="1920" height="1200" alt="localhost_4200_translations_list(picsa) (1)" src="https://github.com/user-attachments/assets/f52ae170-507e-4361-987e-68398d137d2f" />

**Screenshot** - full display still available, limited space leads to mobile-first layout for tool

<img width="1920" height="1200" alt="localhost_4200_translations_list(picsa) (2)" src="https://github.com/user-attachments/assets/cd2f6848-73c8-4894-87f5-7c12fd2a911f" />


---

## AI Summary

> Will be generated on PR open. Regenerate by typing comment `/describe` in PR
> More info at https://docs.pr-agent.ai/tools/describe/

### Description

### 🤖 Generated by PR Agent at 55aade0c1252a428fdf8504a8467c904ee6c93b2

- Add collapsible sidebar with persistence via localStorage
- Implement hover-to-expand behavior for collapsed state
- Add comprehensive test coverage for sidebar functionality
- Update styling for collapsed and expanded states


### Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>authenticated-layout.component.spec.ts</strong><dd><code>Add sidebar component tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-apps/dashboard/src/app/layout/authenticated-layout/authenticated-layout.component.spec.ts

<ul><li>Create comprehensive test suite for sidebar functionality<br> <li> Test localStorage persistence of collapse state<br> <li> Test hover behavior and computed expanded state<br> <li> Mock Supabase and deployment services for testing</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/659/files#diff-2532f468336d28bd4ac32cdc83db84f86631a9eaa1f192558e4d8c0706f0e0c2">+96/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>authenticated-layout.ts</strong><dd><code>Add sidebar collapse/hover logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-apps/dashboard/src/app/layout/authenticated-layout/authenticated-layout.ts

<ul><li>Add signals for collapse and hover states<br> <li> Add computed signal for effective expanded state<br> <li> Implement toggle and hover methods with localStorage<br> <li> Export SIDEBAR_COLLAPSED_KEY constant for testing</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/659/files#diff-b1dff6c01c5272ec097c5854c1ec3d8a76dca6e589182735d355d7a2fd79d943">+40/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>authenticated-layout.html</strong><dd><code>Update template for collapsible sidebar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-apps/dashboard/src/app/layout/authenticated-layout/authenticated-layout.html

<ul><li>Add toggle button to toolbar with icon switching<br> <li> Add mouseenter/mouseleave events to sidebar<br> <li> Conditionally show labels and footer based on state<br> <li> Add tooltip for collapsed navigation items</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/659/files#diff-5aabdceb35c767c94b8f5e22978c53b1524102d2ca6675b701f949a0814ea9f9">+46/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>authenticated-layout.scss</strong><dd><code>Add collapsible sidebar styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-apps/dashboard/src/app/layout/authenticated-layout/authenticated-layout.scss

<ul><li>Add transitions for sidebar width changes<br> <li> Style collapsed and hovered states with box shadows<br> <li> Adjust content margin when sidebar is collapsed<br> <li> Style active links with primary color theming</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/659/files#diff-0577afdbd2eb54fe003cddcec014e5a12ad17e042b36b0b41c50ddce98317cd1">+68/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_overrides.scss</strong><dd><code>Fix scrollbar in collapsed sidebar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/theme/src/_overrides.scss

<ul><li>Hide horizontal scrollbars in collapsed sidebar<br> <li> Add CSS rule targeting collapsed sidebar container</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/659/files#diff-77d7722e654b437bf4ca63be30d1679fcaac6176a825ea4b7de243dc65250989">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

### Diagram


```mermaid
flowchart LR
  A[User clicks toggle button] --> B["Update isCollapsed signal"]
  B --> C[Persist to localStorage]
  B --> D[Toggle sidebar CSS class]
  E[Mouse enter collapsed sidebar] --> F[Set isHovered signal]
  F --> G[Expand sidebar temporarily]
  G --> H[Add drop shadow]
```

#