### PR TITLE
feat: remote server backup

### DIFF
--- a/apps/picsa-apps/app-native/android/app/build.gradle
+++ b/apps/picsa-apps/app-native/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "io.picsa.extension"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 5007004
-        versionName "5.7.4"
+        versionCode 5008000
+        versionName "5.8.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/apps/picsa-server/.env
+++ b/apps/picsa-server/.env
@@ -5,3 +5,7 @@ SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1k
 SUPABASE_SERVICE_ROLE_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU"
 
 # Use a `.env.local` file if overriding with production credentials 
+
+# Key to provide access to supabase remote instance
+# Used by backup scripts
+SUPABASE_REMOTE_ANON_KEY=

--- a/apps/picsa-server/project.json
+++ b/apps/picsa-server/project.json
@@ -82,6 +82,34 @@
         "commands": ["npx supabase"],
         "cwd": "apps/picsa-server"
       }
+    },
+    "backup": {
+      "executor": "nx:run-commands",
+      "dependsOn": [],
+      "outputs": [],
+      "options": {
+        "command": "yarn tsx scripts/backup/backup.ts",
+        "cwd": "apps/picsa-server"
+      }
+    },
+    "backup-db": {
+      "executor": "nx:run-commands",
+      "dependsOn": [],
+      "outputs": [],
+      "options": {
+        "command": "yarn tsx scripts/backup/backup-db.ts",
+        "cwd": "apps/picsa-server"
+      }
+    },
+    "backup-storage": {
+      "executor": "nx:run-commands",
+      "dependsOn": [],
+      "outputs": [],
+      "options": {
+        "command": "yarn tsx scripts/backup/backup-storage.ts",
+        "cwd": "apps/picsa-server"
+      }
     }
   }
 }
+

--- a/apps/picsa-server/scripts/backup/backup-db.ts
+++ b/apps/picsa-server/scripts/backup/backup-db.ts
@@ -1,0 +1,214 @@
+import execa from 'execa';
+import fs from 'fs';
+import path from 'path';
+
+const backupDir = path.resolve(__dirname, './backups');
+const serverRootDir = path.resolve(__dirname, '../..');
+const projectRefFile = path.resolve(serverRootDir, 'supabase/.temp/project-ref');
+const configTomlPath = path.resolve(serverRootDir, 'supabase/config.toml');
+const migrationsDir = path.resolve(serverRootDir, 'supabase/migrations');
+
+export interface ILinkStatus {
+  isLinked: boolean;
+  projectRef?: string;
+  dbUrl?: string;
+}
+
+export function checkSupabaseLinkStatus(): ILinkStatus {
+  if (process.env.SUPABASE_DB_URL) {
+    return { isLinked: true, dbUrl: process.env.SUPABASE_DB_URL };
+  }
+
+  if (process.env.SUPABASE_PROJECT_ID) {
+    return { isLinked: true, projectRef: process.env.SUPABASE_PROJECT_ID };
+  }
+
+  if (fs.existsSync(projectRefFile)) {
+    const projectRef = fs.readFileSync(projectRefFile, 'utf-8').trim();
+    if (projectRef.length > 0) {
+      return { isLinked: true, projectRef };
+    }
+  }
+
+  return { isLinked: false };
+}
+
+/**
+ * Dynamically discovers application schemas by inspecting:
+ * 1. SUPABASE_BACKUP_SCHEMAS environment variable (if specified)
+ * 2. API schemas defined in supabase/config.toml
+ * 3. Custom schemas defined via CREATE SCHEMA in database migration SQL files
+ * Automatically excludes internal Supabase system & platform infrastructure schemas.
+ */
+export function getAppSchemas(): string[] {
+  if (process.env.SUPABASE_BACKUP_SCHEMAS) {
+    return process.env.SUPABASE_BACKUP_SCHEMAS.split(',').map((s) => s.trim());
+  }
+
+  const detectedSchemas = new Set<string>(['public']);
+
+  // Internal system and infrastructure schemas to exclude
+  const excludedSchemas = new Set([
+    'graphql_public',
+    'graphql',
+    'vault',
+    'auth',
+    'extensions',
+    'realtime',
+    'pgbouncer',
+    'supabase_functions',
+    'supabase_migrations',
+    'storage',
+    'cron',
+    'net',
+    'information_schema',
+    'audit',
+  ]);
+
+  // 1. Discover schemas exposed in config.toml
+  if (fs.existsSync(configTomlPath)) {
+    const configContent = fs.readFileSync(configTomlPath, 'utf-8');
+    const schemasMatch = configContent.match(/schemas\s*=\s*\[(.*?)\]/s);
+    if (schemasMatch && schemasMatch[1]) {
+      const parsedSchemas = schemasMatch[1].split(',').map((s) => s.trim().replace(/['"]/g, ''));
+
+      for (const s of parsedSchemas) {
+        if (s && !excludedSchemas.has(s)) {
+          detectedSchemas.add(s);
+        }
+      }
+    }
+  }
+
+  // 2. Discover custom application schemas created in SQL migrations
+  if (fs.existsSync(migrationsDir)) {
+    try {
+      const entries = fs.readdirSync(migrationsDir, { recursive: true });
+      for (const entry of entries) {
+        const fileStr = String(entry);
+        if (fileStr.endsWith('.sql')) {
+          const filePath = path.join(migrationsDir, fileStr);
+          const sqlContent = fs.readFileSync(filePath, 'utf-8');
+          const matches = sqlContent.matchAll(
+            /create\s+schema\s+(?:if\s+not\s+exists\s+)?["`']?([a-zA-Z0-9_]+)["`']?/gi,
+          );
+          for (const match of matches) {
+            const schemaName = match[1]?.toLowerCase();
+            if (schemaName && !excludedSchemas.has(schemaName)) {
+              detectedSchemas.add(schemaName);
+            }
+          }
+        }
+      }
+    } catch {
+      // Ignore migration scanning errors if folder structure differs
+    }
+  }
+
+  return Array.from(detectedSchemas);
+}
+
+/**
+ * Returns tables to exclude from data-only dump.
+ * Default: public.app_users, public.user_profiles, public.forecasts, public.climate_station_data
+ * Can be overridden via SUPABASE_EXCLUDE_TABLES environment variable.
+ */
+export function getExcludedTables(): string[] {
+  if (process.env.SUPABASE_EXCLUDE_TABLES) {
+    return process.env.SUPABASE_EXCLUDE_TABLES.split(',').map((t) => t.trim());
+  }
+
+  return ['public.app_users', 'public.user_profiles', 'public.forecasts', 'public.climate_station_data'];
+}
+
+export async function backupDatabase() {
+  console.log('Checking Supabase connection status...');
+  const linkStatus = checkSupabaseLinkStatus();
+
+  if (!linkStatus.isLinked) {
+    console.error('\n❌ Error: Supabase CLI is not linked to a remote project.');
+    console.error('Please run the following command from apps/picsa-server to link your project:');
+    console.error('  npx supabase link --project-ref <YOUR_PROJECT_REF>\n');
+    console.error('Or set SUPABASE_DB_URL or SUPABASE_PROJECT_ID in your environment.\n');
+    process.exit(1);
+  }
+
+  if (linkStatus.projectRef) {
+    console.log(`Linked remote project reference: ${linkStatus.projectRef}`);
+  }
+
+  const appSchemas = getAppSchemas();
+  const excludedTables = getExcludedTables();
+
+  console.log(`Application schemas dynamically discovered: ${appSchemas.join(', ')}`);
+  if (excludedTables.length > 0) {
+    console.log(`Tables excluded from data dump: ${excludedTables.join(', ')}`);
+  }
+
+  if (!fs.existsSync(backupDir)) {
+    fs.mkdirSync(backupDir, { recursive: true });
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').substring(0, 19);
+  const schemaFile = path.join(backupDir, `db_schema_${timestamp}.sql`);
+  const dataFile = path.join(backupDir, `db_data_${timestamp}.sql`);
+
+  const baseArgs = linkStatus.dbUrl ? ['--db-url', linkStatus.dbUrl] : ['--linked'];
+  const schemaArgs = ['-s', appSchemas.join(',')];
+  const excludeArgs = excludedTables.length > 0 ? ['-x', excludedTables.join(',')] : [];
+
+  try {
+    console.log(`\n[+] Dumping DB Schema to ${schemaFile}...`);
+    await execa('npx', ['supabase', 'db', 'dump', ...baseArgs, ...schemaArgs, '-f', schemaFile], {
+      cwd: serverRootDir,
+      stdio: 'inherit',
+    });
+
+    console.log(`[+] Dumping DB Data to ${dataFile}...`);
+    await execa(
+      'npx',
+      [
+        'supabase',
+        'db',
+        'dump',
+        ...baseArgs,
+        ...schemaArgs,
+        ...excludeArgs,
+        '--data-only',
+        '--use-copy',
+        '-f',
+        dataFile,
+      ],
+      {
+        cwd: serverRootDir,
+        stdio: 'inherit',
+      },
+    );
+
+    console.log('\n✅ Database backup completed successfully.');
+    console.log(`   Schema: ${schemaFile}`);
+    console.log(`   Data:   ${dataFile}`);
+  } catch (error: any) {
+    console.error('\n❌ Database backup failed:', error?.message || error);
+    formatErrorGuidance(error?.message || String(error));
+    process.exit(1);
+  }
+}
+
+function formatErrorGuidance(errorMessage: string) {
+  if (
+    errorMessage.includes('Not logged in') ||
+    errorMessage.includes('Unauthorized') ||
+    errorMessage.includes('access token')
+  ) {
+    console.error('\n💡 Troubleshooting: You need to authenticate with Supabase CLI.');
+    console.error('  Run: npx supabase login\n');
+  } else if (errorMessage.includes('password') || errorMessage.includes('authentication failed')) {
+    console.error('\n💡 Troubleshooting: Database password is required.');
+    console.error('  Set SUPABASE_DB_PASSWORD environment variable or provide password when prompted.\n');
+  }
+}
+
+if (require.main === module) {
+  backupDatabase();
+}

--- a/apps/picsa-server/scripts/backup/backup-storage.ts
+++ b/apps/picsa-server/scripts/backup/backup-storage.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path, { relative, resolve } from 'path';
 import crypto from 'crypto';
 import { zipFolderContents } from '../utils/file.utils';
-import { getSupabaseClient } from '../utils/supabase.utils';
+import { getRemoteSupabaseClient } from '../utils/supabase.utils';
 
 interface IFileMeta extends FileObject {
   bucketName: string;
@@ -69,7 +69,7 @@ async function syncFiles(remoteFiles: IFileMeta[]) {
   }
 }
 async function syncFile(remoteFile: IFileMeta) {
-  const supabase = getSupabaseClient();
+  const supabase = getRemoteSupabaseClient();
   const status = { downloaded: false, skipped: false, error: null as any };
   const { filePath, created_at, updated_at, bucketName, metadata } = remoteFile;
   const localFilePath = path.join(localDir, bucketName, filePath);
@@ -118,19 +118,20 @@ function removeOrphaned(bucketName: string, remoteFiles: IFileMeta[]) {
 
   const baseDir = resolve(localDir, bucketName);
 
+  if (!fs.existsSync(baseDir)) {
+    return;
+  }
+
   const remoteHashmap = remoteFiles.reduce((map, f) => {
     map.set(f.filePath, f);
     return map;
   }, new Map<string, IFileMeta>());
 
   function walkDir(dir: string) {
+    if (!fs.existsSync(dir)) return;
     const files = fs.readdirSync(dir, { withFileTypes: true });
-    // Remove empty directories
-    if (files.length === 0) {
-      fs.rmdirSync(dir);
-    }
     for (const file of files) {
-      const childPath = resolve(file.parentPath, file.name);
+      const childPath = resolve(dir, file.name);
       if (file.isDirectory()) {
         walkDir(childPath);
       } else {
@@ -141,6 +142,11 @@ function removeOrphaned(bucketName: string, remoteFiles: IFileMeta[]) {
           removedCount++;
         }
       }
+    }
+    // Clean up empty subdirectories (except base directory)
+    const remainingFiles = fs.readdirSync(dir);
+    if (remainingFiles.length === 0 && dir !== baseDir) {
+      fs.rmdirSync(dir);
     }
   }
 
@@ -161,7 +167,7 @@ function calculateMD5(filePath: string) {
 }
 
 async function listBuckets() {
-  const supabase = getSupabaseClient();
+  const supabase = getRemoteSupabaseClient();
   const { data, error } = await supabase.storage.listBuckets();
 
   if (error) {
@@ -176,7 +182,7 @@ async function listBuckets() {
 
 // List all files in the bucket (recursively)
 async function listFiles(bucketName: string, prefix = '') {
-  const supabase = getSupabaseClient();
+  const supabase = getRemoteSupabaseClient();
   // skip list of omitted files
   if (omitDirs.includes(prefix)) return [];
 
@@ -202,4 +208,8 @@ async function listFiles(bucketName: string, prefix = '') {
   }
 
   return allFiles;
+}
+
+if (require.main === module) {
+  backupStorage();
 }

--- a/apps/picsa-server/scripts/backup/backup-storage.ts
+++ b/apps/picsa-server/scripts/backup/backup-storage.ts
@@ -168,16 +168,30 @@ function calculateMD5(filePath: string) {
 
 async function listBuckets() {
   const supabase = getRemoteSupabaseClient();
-  const { data, error } = await supabase.storage.listBuckets();
+  try {
+    const { data, error } = await supabase.storage.listBuckets();
+    if (!error && data && data.length > 0) {
+      return data.filter(({ name }) => !omitBuckets.includes(name));
+    }
+  } catch {
+    // Ignore listBuckets API error for non-service-role keys
+  }
 
-  if (error) {
-    throw error;
+  // Fallback for anon key: query distinct bucket_ids dynamically from storage.objects table
+  const { data: objectRows, error: dbError } = await supabase
+    .schema('storage' as any)
+    .from('objects')
+    .select('bucket_id');
+
+  if (dbError || !objectRows) {
+    throw new Error(`Failed to list storage buckets from storage.objects: ${dbError?.message || 'No data returned'}`);
   }
-  if (!data || data.length === 0) {
-    throw new Error(`No buckets listed - make sure you use an access token with permissions`);
-  }
-  const buckets = data || [];
-  return buckets.filter(({ name }) => !omitBuckets.includes(name));
+
+  const uniqueBucketNames = Array.from(new Set(objectRows.map((r: any) => r.bucket_id))).filter(
+    (name): name is string => Boolean(name) && !omitBuckets.includes(name),
+  );
+
+  return uniqueBucketNames.map((name) => ({ name, id: name, public: true }));
 }
 
 // List all files in the bucket (recursively)
@@ -186,28 +200,61 @@ async function listFiles(bucketName: string, prefix = '') {
   // skip list of omitted files
   if (omitDirs.includes(prefix)) return [];
 
+  // Try standard storage list API first
   const { data, error } = await supabase.storage.from(bucketName).list(prefix);
 
-  if (error) {
-    console.error(`Error listing files with prefix ${prefix}:`, error);
+  if (!error && data) {
+    let allFiles: IFileMeta[] = [];
+    for (const item of data) {
+      if (item.id) {
+        // It's a file
+        const filePath = prefix ? `${prefix}/${item.name}` : item.name;
+        allFiles.push({ ...item, filePath, bucketName });
+      } else {
+        // It's a folder
+        const subPrefix = prefix ? `${prefix}/${item.name}` : item.name;
+        const subFiles = await listFiles(bucketName, subPrefix);
+        allFiles = [...allFiles, ...subFiles];
+      }
+    }
+    return allFiles;
+  }
+
+  // Fallback for anon key: Query storage.objects table directly (works under public RLS policies)
+  let query = supabase
+    .schema('storage' as any)
+    .from('objects')
+    .select('id, name, created_at, updated_at, metadata')
+    .eq('bucket_id', bucketName);
+
+  if (prefix) {
+    query = query.like('name', `${prefix}/%`);
+  }
+
+  const { data: dbObjects, error: dbErr } = await query;
+
+  if (dbErr || !dbObjects) {
+    console.error(`Error querying storage.objects for bucket ${bucketName}:`, dbErr);
     return [];
   }
-  let allFiles: IFileMeta[] = [];
 
-  for (const item of data) {
-    if (item.id) {
-      // It's a file
-      const filePath = prefix ? `${prefix}/${item.name}` : item.name;
-      allFiles.push({ ...item, filePath, bucketName });
-    } else {
-      // It's a folder
-      const subPrefix = prefix ? `${prefix}/${item.name}` : item.name;
-      const subFiles = await listFiles(bucketName, subPrefix);
-      allFiles = [...allFiles, ...subFiles];
-    }
-  }
-
-  return allFiles;
+  return dbObjects
+    .filter((obj: any) => {
+      // Exclude omitted directories
+      if (omitDirs.some((d) => obj.name.startsWith(`${d}/`) || obj.name === d)) {
+        return false;
+      }
+      return true;
+    })
+    .map((obj: any) => ({
+      id: obj.id,
+      name: path.basename(obj.name),
+      created_at: obj.created_at,
+      updated_at: obj.updated_at,
+      metadata: obj.metadata || {},
+      filePath: obj.name,
+      bucketName,
+    }));
 }
 
 if (require.main === module) {

--- a/apps/picsa-server/scripts/backup/backup-storage.ts
+++ b/apps/picsa-server/scripts/backup/backup-storage.ts
@@ -18,7 +18,7 @@ const backupDir = path.resolve(__dirname, './backups');
 const omitDirs = ['forecasts'];
 
 /** List of buckets to exclude from local backup */
-const omitBuckets: string[] = [];
+const omitBuckets: string[] = ['apk-releases'];
 
 /** Export all supabase storage files to local cache and store as timestamped archive */
 export async function backupStorage() {

--- a/apps/picsa-server/scripts/backup/backup.ts
+++ b/apps/picsa-server/scripts/backup/backup.ts
@@ -1,6 +1,8 @@
+import { backupDatabase } from './backup-db';
 import { backupStorage } from './backup-storage';
 
 async function backup() {
+  await backupDatabase();
   await backupStorage();
 }
 

--- a/apps/picsa-server/scripts/utils/supabase.utils.ts
+++ b/apps/picsa-server/scripts/utils/supabase.utils.ts
@@ -1,10 +1,13 @@
 import type { Database } from '../../supabase/types';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import fs from 'fs';
+import path from 'path';
 
 let supabase: SupabaseClient<Database>;
+let remoteSupabase: SupabaseClient<Database>;
 
 /**
- * Retrieve service-role supabase client using stored env credentials
+ * Retrieve service-role supabase client using stored env credentials for local Docker development
  */
 export function getSupabaseClient() {
   if (supabase) return supabase;
@@ -17,4 +20,97 @@ export function getSupabaseClient() {
   }
   supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   return supabase;
+}
+
+/**
+ * Ensures .env.local is loaded if present in apps/picsa-server
+ */
+export function loadEnvLocal() {
+  const serverDir = path.resolve(__dirname, '../../');
+  const envLocalPath = path.resolve(serverDir, '.env.local');
+  if (fs.existsSync(envLocalPath)) {
+    try {
+      const dotenv = require('dotenv');
+      dotenv.config({ path: envLocalPath, override: true });
+    } catch {
+      // Ignore if dotenv is not available
+    }
+  }
+}
+
+/**
+ * Retrieve remote project reference from CLI link state or environment
+ */
+export function getLinkedProjectRef(): string | null {
+  const serverRootDir = path.resolve(__dirname, '../..');
+  const projectRefFile = path.resolve(serverRootDir, 'supabase/.temp/project-ref');
+
+  if (process.env.SUPABASE_PROJECT_ID) {
+    return process.env.SUPABASE_PROJECT_ID;
+  }
+  if (fs.existsSync(projectRefFile)) {
+    const projectRef = fs.readFileSync(projectRefFile, 'utf-8').trim();
+    if (projectRef.length > 0) {
+      return projectRef;
+    }
+  }
+  return null;
+}
+
+/**
+ * Retrieve Supabase client specifically targeting REMOTE instance for storage backups.
+ * Checks for remote credentials in environment or .env.local:
+ * - SUPABASE_REMOTE_URL (or derived https://<projectRef>.supabase.co)
+ * - SUPABASE_REMOTE_ANON_KEY / SUPABASE_REMOTE_SERVICE_ROLE_KEY / SUPABASE_ANON_KEY / SUPABASE_SERVICE_ROLE_KEY
+ */
+export function getRemoteSupabaseClient() {
+  if (remoteSupabase) return remoteSupabase;
+
+  loadEnvLocal();
+
+  let remoteUrl = process.env.SUPABASE_REMOTE_URL;
+  if (!remoteUrl) {
+    const projectRef = getLinkedProjectRef();
+    if (projectRef) {
+      remoteUrl = `https://${projectRef}.supabase.co`;
+    } else if (
+      process.env.SUPABASE_URL &&
+      !process.env.SUPABASE_URL.includes('localhost') &&
+      !process.env.SUPABASE_URL.includes('127.0.0.1')
+    ) {
+      remoteUrl = process.env.SUPABASE_URL;
+    }
+  }
+
+  if (!remoteUrl) {
+    console.error('\n❌ Error: Cannot determine remote Supabase URL.');
+    console.error('  Please link your project (`npx supabase link --project-ref <REF>`)');
+    console.error('  or specify SUPABASE_REMOTE_URL in apps/picsa-server/.env.local\n');
+    process.exit(1);
+  }
+
+  const apiKey =
+    process.env.SUPABASE_REMOTE_ANON_KEY ||
+    process.env.SUPABASE_REMOTE_SERVICE_ROLE_KEY ||
+    (process.env.SUPABASE_ANON_KEY && !process.env.SUPABASE_ANON_KEY.includes('eyJpc3MiOiJzdXBhYmFzZS1kZW1v')
+      ? process.env.SUPABASE_ANON_KEY
+      : '') ||
+    (process.env.SUPABASE_SERVICE_ROLE_KEY &&
+    !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('eyJpc3MiOiJzdXBhYmFzZS1kZW1v')
+      ? process.env.SUPABASE_SERVICE_ROLE_KEY
+      : '');
+
+  if (!apiKey) {
+    console.error('\n❌ Error: Remote Supabase API key is missing.');
+    console.error(
+      '  Please set SUPABASE_REMOTE_ANON_KEY (or SUPABASE_REMOTE_SERVICE_ROLE_KEY) in apps/picsa-server/.env.local',
+    );
+    console.error(`  Target Remote URL: ${remoteUrl}\n`);
+    process.exit(1);
+  }
+
+  console.log(`[Remote Storage Client] Target Remote Server: ${remoteUrl}\n`);
+
+  remoteSupabase = createClient<Database>(remoteUrl, apiKey);
+  return remoteSupabase;
 }

--- a/apps/picsa-server/scripts/utils/supabase.utils.ts
+++ b/apps/picsa-server/scripts/utils/supabase.utils.ts
@@ -29,12 +29,8 @@ export function loadEnvLocal() {
   const serverDir = path.resolve(__dirname, '../../');
   const envLocalPath = path.resolve(serverDir, '.env.local');
   if (fs.existsSync(envLocalPath)) {
-    try {
-      const dotenv = require('dotenv');
-      dotenv.config({ path: envLocalPath, override: true });
-    } catch {
-      // Ignore if dotenv is not available
-    }
+    const dotenv = require('dotenv');
+    dotenv.config({ path: envLocalPath, override: true });
   }
 }
 
@@ -61,7 +57,10 @@ export function getLinkedProjectRef(): string | null {
  * Retrieve Supabase client specifically targeting REMOTE instance for storage backups.
  * Checks for remote credentials in environment or .env.local:
  * - SUPABASE_REMOTE_URL (or derived https://<projectRef>.supabase.co)
- * - SUPABASE_REMOTE_ANON_KEY / SUPABASE_REMOTE_SERVICE_ROLE_KEY / SUPABASE_ANON_KEY / SUPABASE_SERVICE_ROLE_KEY
+ * - SUPABASE_REMOTE_ANON_KEY
+ *
+ * NOTE - currently configured just for anon access. Could also be configured for service-role
+ * access in future if required
  */
 export function getRemoteSupabaseClient() {
   if (remoteSupabase) return remoteSupabase;
@@ -89,22 +88,11 @@ export function getRemoteSupabaseClient() {
     process.exit(1);
   }
 
-  const apiKey =
-    process.env.SUPABASE_REMOTE_ANON_KEY ||
-    process.env.SUPABASE_REMOTE_SERVICE_ROLE_KEY ||
-    (process.env.SUPABASE_ANON_KEY && !process.env.SUPABASE_ANON_KEY.includes('eyJpc3MiOiJzdXBhYmFzZS1kZW1v')
-      ? process.env.SUPABASE_ANON_KEY
-      : '') ||
-    (process.env.SUPABASE_SERVICE_ROLE_KEY &&
-    !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('eyJpc3MiOiJzdXBhYmFzZS1kZW1v')
-      ? process.env.SUPABASE_SERVICE_ROLE_KEY
-      : '');
+  const apiKey = process.env.SUPABASE_REMOTE_ANON_KEY;
 
   if (!apiKey) {
     console.error('\n❌ Error: Remote Supabase API key is missing.');
-    console.error(
-      '  Please set SUPABASE_REMOTE_ANON_KEY (or SUPABASE_REMOTE_SERVICE_ROLE_KEY) in apps/picsa-server/.env.local',
-    );
+    console.error('  Please set SUPABASE_REMOTE_ANON_KEY in apps/picsa-server/.env.local');
     console.error(`  Target Remote URL: ${remoteUrl}\n`);
     process.exit(1);
   }

--- a/apps/picsa-server/supabase/functions/.env.local.example
+++ b/apps/picsa-server/supabase/functions/.env.local.example
@@ -1,1 +1,5 @@
+# Key to provide access to supabase remote instance
+# Used by backup scripts
+SUPABASE_REMOTE_ANON_KEY=
+
 KOBO_API_KEY=

--- a/apps/picsa-server/supabase/functions/.env.local.example
+++ b/apps/picsa-server/supabase/functions/.env.local.example
@@ -1,5 +1,1 @@
-# Key to provide access to supabase remote instance
-# Used by backup scripts
-SUPABASE_REMOTE_ANON_KEY=
-
 KOBO_API_KEY=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picsa-apps",
-  "version": "5.7.4",
+  "version": "5.8.0",
   "license": "See LICENSE",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Developer Summary

> Info for reviewer, e.g. use of ai, pain points/challenges, discussion points for monthly dev call

## Related Issues

> Link any related issues (e.g., `Closes #[issue_number]`, `Relates to #[issue_number]`)

## Screenshots / Videos

> Include at least 1-2 screenshots of videos if visual changes

---

## AI Summary

> Will be generated on PR open. Regenerate by typing comment `/describe` in PR
> More info at https://docs.pr-agent.ai/tools/describe/

### Description

### 🤖 Generated by PR Agent at 7478ca3785293e0da3a9f39c493e6dbd8769cfc4

- Add remote Supabase database backup script
- Support remote storage backup with anon key fallback
- Add Nx backup commands and project config
- Update env config and orphan file cleanup


### Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backup-db.ts</strong><dd><code>Add remote database backup script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-server/scripts/backup/backup-db.ts

<ul><li>New script to dump remote Supabase database schema and data<br> <li> Dynamically discovers app schemas from config.toml and SQL migrations<br> <li> Supports excluding tables via env variable<br> <li> Provides auth and password error troubleshooting guidance</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/670/files#diff-d30bcde84b7e970f702a8d5bdaa8f3fb7c1f89438d14e8c7c34ff29b1683e140">+214/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backup-storage.ts</strong><dd><code>Enable remote storage backup with anon key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-server/scripts/backup/backup-storage.ts

<ul><li>Switches to remote Supabase client for storage backup<br> <li> Adds fallback to query storage.objects table when using anon key<br> <li> Skips apk-releases bucket by default<br> <li> Fixes orphan directory cleanup to avoid removing base dir</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/670/files#diff-f61504b20c2722b86391fac508a6b006752d4df947ce97baf18a274f6bee575a">+92/-35</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backup.ts</strong><dd><code>Combine database and storage backups</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-server/scripts/backup/backup.ts

<ul><li>Orchestrates database and storage backup sequence<br> <li> Calls backupDatabase before backupStorage</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/670/files#diff-745fb9b3459200b6d775c033ce9c3eb26eee8cb448d2690ad4389aa0f2d82292">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>supabase.utils.ts</strong><dd><code>Add remote Supabase client utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-server/scripts/utils/supabase.utils.ts

<ul><li>Adds getRemoteSupabaseClient factory targeting remote instance<br> <li> Loads .env.local for remote credentials<br> <li> Resolves remote URL from project-ref or env variable<br> <li> Filters out demo key values when picking API key</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/670/files#diff-3e9f1089d5c879b21668d29f283bbfaa11c3ffb3181552b6e0cbe7b7c76a1343">+97/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.env</strong><dd><code>Document remote anon key env variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-server/.env

- Adds placeholder SUPABASE_REMOTE_ANON_KEY for remote backups


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/670/files#diff-36f497d8ced9299a8c116654055233691a0e7d9a9010dda4f4e732f5b8a8e1e9">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>project.json</strong><dd><code>Add Nx backup command targets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-server/project.json

<ul><li>Adds Nx targets for backup, backup-db, and backup-storage<br> <li> Wires commands to run tsx scripts in server workspace</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/670/files#diff-9ff42e9fc6975df1886d480ae3117d2e4387d34f2b6f69067ab3935c9bc17508">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

### Diagram


```mermaid
flowchart LR
  A["Nx:backup command"] --> B["backup.ts"]
  B --> C["backupDatabase()"]
  B --> D["backupStorage()"]
  C --> E["npx supabase db dump --linked"]
  C --> F["Excluded tables & schemas"]
  D --> G["getRemoteSupabaseClient()"]
  G --> H["storage API fallback"]
  H --> I["storage.objects table query"]
  I --> J["Local backup files"]
```