### PR TITLE
feat(crop-probability): grouped variety outputs

### DIFF
--- a/apps/picsa-apps/dashboard/src/app/modules/crop-information/utils/probability.utils.spec.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/crop-information/utils/probability.utils.spec.ts
@@ -1,3 +1,9 @@
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import {
+  getDaysBounds,
+  groupAndSortCropDataItems,
+} from '@picsa/crop-probability/src/app/utils/probability-table.utils';
+
 import { findSurroundingKeys, getCropSuccessProbability, linearInterpolationStrategy } from './probability.utils';
 
 describe('probability.utils', () => {
@@ -65,6 +71,94 @@ describe('probability.utils', () => {
       const result = getCropSuccessProbability(250, 60, [100, 200], sparseHashmap);
       expect(result[0]).toBe(0.2);
       expect(result[1]).toBe(0.8);
+    });
+  });
+
+  describe('getDaysBounds', () => {
+    it('should use numeric days_lower and days_upper directly', () => {
+      expect(getDaysBounds({ variety: 'V1', days: '130 - 135', days_lower: 130, days_upper: 135 })).toEqual({
+        minDays: 130,
+        maxDays: 135,
+        midpoint: 132.5,
+      });
+    });
+
+    it('should fallback to parsing string if numeric properties are missing', () => {
+      expect(getDaysBounds({ variety: 'V1', days: '90' })).toEqual({
+        minDays: 90,
+        maxDays: 90,
+        midpoint: 90,
+      });
+      expect(getDaysBounds({ variety: 'V1', days: '130 - 135' })).toEqual({
+        minDays: 130,
+        maxDays: 135,
+        midpoint: 132.5,
+      });
+    });
+  });
+
+  describe('groupAndSortCropDataItems', () => {
+    it('should group items with identical water and probability requirements into a single row', () => {
+      const input = [
+        {
+          variety: 'SC600',
+          days: '130',
+          days_lower: 130,
+          days_upper: 130,
+          water: [364],
+          probabilities: [0.6, 0.2, 0, 0],
+        },
+        {
+          variety: 'PHB 30 G 19',
+          days: '135',
+          days_lower: 135,
+          days_upper: 135,
+          water: [364],
+          probabilities: [0.6, 0.2, 0, 0],
+        },
+      ];
+
+      const result = groupAndSortCropDataItems(input);
+      expect(result.length).toBe(1);
+      expect(result[0].variety).toBe('SC600, PHB 30 G 19');
+      expect(result[0].days).toBe('130 - 135');
+      expect(result[0].days_lower).toBe(130);
+      expect(result[0].days_upper).toBe(135);
+      expect(result[0].water).toEqual([364]);
+      expect(result[0].probabilities).toEqual([0.6, 0.2, 0, 0]);
+    });
+
+    it('should sort grouped items in ascending order of days midpoint', () => {
+      const input = [
+        {
+          variety: 'Late Variety',
+          days: '130 - 135',
+          days_lower: 130,
+          days_upper: 135,
+          water: [364],
+          probabilities: [0.6, 0.2, 0, 0],
+        },
+        {
+          variety: 'Early Variety',
+          days: '90',
+          days_lower: 90,
+          days_upper: 90,
+          water: [252],
+          probabilities: [1, 1, 0.8, 0.6],
+        },
+        {
+          variety: 'Medium Variety',
+          days: '110',
+          days_lower: 110,
+          days_upper: 110,
+          water: [308],
+          probabilities: [1, 0.8, 0.5, 0.1],
+        },
+      ];
+
+      const result = groupAndSortCropDataItems(input);
+      expect(result.map((r) => r.variety)).toEqual(['Early Variety', 'Medium Variety', 'Late Variety']);
+      expect(result.map((r) => r.days)).toEqual(['90', '110', '130 - 135']);
     });
   });
 });

--- a/apps/picsa-apps/dashboard/src/app/modules/crop-information/utils/probability.utils.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/crop-information/utils/probability.utils.ts
@@ -1,5 +1,7 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import type { IStationCropData } from '@picsa/crop-probability/src/app/models';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { groupAndSortCropDataItems } from '@picsa/crop-probability/src/app/utils/probability-table.utils';
 import { ICropName, MONTH_DATA } from '@picsa/data';
 
 import type { IAnnualRainfallSummariesData, ICropSuccessEntry } from '../../climate/types';
@@ -243,10 +245,10 @@ export function generateTable(params: {
           upper: getCropSuccessProbability(waterRequirement, days_upper, plantDates, probabilityHashmap),
         };
         const probabilityValues = generateProbabilityEntryValues(probabilities, plantDates);
-        // HACK - convert to legacy table format
-        // TODO - review and possibly tidy up
         entry.data.push({
           days: [...new Set([days.lower, days_upper])].join(' - '),
+          days_lower: days.lower,
+          days_upper: days.upper,
           variety,
           probabilities: probabilityValues,
           water: [waterRequirement],
@@ -256,24 +258,7 @@ export function generateTable(params: {
       }
     }
 
-    // Sort varieties within this crop by days to maturity midpoint (shorter days first)
-    entry.data.sort((a, b) => {
-      const aData = cropDataHashmap[`${entry.crop}/${a.variety}`];
-      const bData = cropDataHashmap[`${entry.crop}/${b.variety}`];
-      if (!aData || !bData) return 0;
-
-      const aMid = (aData.days_lower + aData.days_upper) / 2;
-      const bMid = (bData.days_lower + bData.days_upper) / 2;
-
-      if (aMid !== bMid) {
-        return aMid - bMid;
-      }
-      if (aData.days_lower !== bData.days_lower) {
-        return aData.days_lower - bData.days_lower;
-      }
-      return a.variety.localeCompare(b.variety);
-    });
-
+    entry.data = groupAndSortCropDataItems(entry.data);
     entries.push(entry);
   }
 

--- a/apps/picsa-tools/crop-probability-tool/src/app/components/crop-probability-table/crop-probability-table.component.spec.ts
+++ b/apps/picsa-tools/crop-probability-tool/src/app/components/crop-probability-table/crop-probability-table.component.spec.ts
@@ -1,5 +1,10 @@
+import { provideHttpClient } from '@angular/common/http';
+import { importProvidersFrom } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { PicsaTranslateModule } from '@picsa/i18n';
 
+import { IStationCropData } from '../../models';
 import { CropProbabilityTableComponent } from './crop-probability-table.component';
 
 describe('CropProbabilityTableComponent', () => {
@@ -8,15 +13,67 @@ describe('CropProbabilityTableComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [CropProbabilityTableComponent],
+      imports: [CropProbabilityTableComponent],
+      providers: [provideHttpClient(), provideRouter([]), importProvidersFrom(PicsaTranslateModule.forRoot())],
     }).compileComponents();
 
     fixture = TestBed.createComponent(CropProbabilityTableComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should group matching requirements and sort table rows by days midpoint', () => {
+    fixture.componentRef.setInput('tableMeta', {
+      id: 'test',
+      label: 'Test Location',
+      station_label: 'Test Station',
+      seasonProbabilities: [1, 0.5],
+      dateHeadings: ['Date 1', 'Date 2'],
+    });
+
+    const mockStationData: IStationCropData[] = [
+      {
+        crop: 'maize',
+        data: [
+          {
+            variety: 'SC600',
+            days: '130',
+            water: [364],
+            probabilities: [0.6, 0.2],
+          },
+          {
+            variety: 'PHB 30 G 19',
+            days: '135',
+            water: [364],
+            probabilities: [0.6, 0.2],
+          },
+          {
+            variety: 'SC403',
+            days: '110',
+            water: [308],
+            probabilities: [1, 0.8],
+          },
+        ],
+      },
+    ];
+
+    fixture.componentRef.setInput('stationData', mockStationData);
+    fixture.detectChanges();
+
+    const rows = component.dataSource.data;
+    expect(rows.length).toBe(2);
+
+    // Row 1 should be early variety (110 days)
+    expect(rows[0].variety).toBe('SC403');
+    expect(rows[0].days).toBe('110');
+    expect(rows[0].cropNameRowspan).toBe(2);
+
+    // Row 2 should be grouped late varieties (130 - 135 days)
+    expect(rows[1].variety).toBe('SC600, PHB 30 G 19');
+    expect(rows[1].days).toBe('130 - 135');
+    expect(rows[1].cropNameRowspan).toBe(0);
   });
 });

--- a/apps/picsa-tools/crop-probability-tool/src/app/components/crop-probability-table/crop-probability-table.component.ts
+++ b/apps/picsa-tools/crop-probability-tool/src/app/components/crop-probability-table/crop-probability-table.component.ts
@@ -7,6 +7,7 @@ import { PicsaTranslateModule } from '@picsa/i18n';
 import { arrayToHashmap } from '@picsa/utils';
 
 import { IProbabilityTableMeta, IStationCropData, IStationCropDataItem } from '../../models';
+import { groupAndSortCropDataItems } from '../../utils/probability-table.utils';
 
 @Component({
   selector: 'crop-probability-table',
@@ -102,14 +103,15 @@ export class CropProbabilityTableComponent implements OnInit {
 
     const entries: ITableRow[] = [];
     for (const { crop, data } of stationData) {
-      data.forEach((item, index) => {
+      const groupedData = groupAndSortCropDataItems(data || []);
+      groupedData.forEach((item, index) => {
         const { probabilities, ...rest } = item;
         for (const { index, name } of this.probabilityColumns()) {
           const val = probabilities?.[index];
           rest[name] = val !== undefined ? val : null;
         }
         // set first row of each to span all crop rows (other rows set to 0 to omit)
-        const cropNameRowspan = index === 0 ? data.length : 0;
+        const cropNameRowspan = index === 0 ? groupedData.length : 0;
         entries.push({ ...rest, crop, cropNameRowspan });
       });
     }

--- a/apps/picsa-tools/crop-probability-tool/src/app/models/index.ts
+++ b/apps/picsa-tools/crop-probability-tool/src/app/models/index.ts
@@ -38,6 +38,8 @@ export interface IStationCropData {
 export interface IStationCropDataItem {
   variety: string;
   days: string;
+  days_lower?: number;
+  days_upper?: number;
   water?: number[];
   probabilities?: (number | null)[];
 }

--- a/apps/picsa-tools/crop-probability-tool/src/app/utils/probability-table.utils.ts
+++ b/apps/picsa-tools/crop-probability-tool/src/app/utils/probability-table.utils.ts
@@ -1,0 +1,100 @@
+import { IStationCropDataItem } from '../models';
+
+/**
+ * Extract numeric min days, max days, and calculated midpoint for a crop item.
+ */
+export function getDaysBounds(item: IStationCropDataItem): { minDays: number; maxDays: number; midpoint: number } {
+  let minDays: number;
+  let maxDays: number;
+
+  if (typeof item.days_lower === 'number' && typeof item.days_upper === 'number') {
+    minDays = item.days_lower;
+    maxDays = item.days_upper;
+  } else {
+    const nums = (item.days || '').match(/\d+/g)?.map(Number) || [];
+    if (nums.length >= 2) {
+      minDays = Math.min(...nums);
+      maxDays = Math.max(...nums);
+    } else if (nums.length === 1) {
+      minDays = nums[0];
+      maxDays = nums[0];
+    } else {
+      minDays = 0;
+      maxDays = 0;
+    }
+  }
+
+  const midpoint = (minDays + maxDays) / 2;
+  return { minDays, maxDays, midpoint };
+}
+
+/**
+ * Group crop items sharing identical water requirements and probabilities into single rows
+ * and sort the grouped rows in ascending order of days midpoint.
+ */
+export function groupAndSortCropDataItems(items: IStationCropDataItem[]): IStationCropDataItem[] {
+  const groupsHashmap = new Map<
+    string,
+    { items: IStationCropDataItem[]; water: number[]; probabilities: (number | null)[] }
+  >();
+
+  for (const item of items) {
+    const waterKey = (item.water || []).join(',');
+    const probKey = JSON.stringify(item.probabilities || []);
+    const reqKey = `${waterKey}|${probKey}`;
+
+    if (!groupsHashmap.has(reqKey)) {
+      groupsHashmap.set(reqKey, {
+        items: [item],
+        water: item.water || [],
+        probabilities: item.probabilities || [],
+      });
+    } else {
+      groupsHashmap.get(reqKey)!.items.push(item);
+    }
+  }
+
+  const result: IStationCropDataItem[] = [];
+
+  for (const group of groupsHashmap.values()) {
+    const varieties = [
+      ...new Set(
+        group.items
+          .flatMap((it) => (it.variety || '').split(/,\s*/))
+          .map((v) => v.trim())
+          .filter(Boolean),
+      ),
+    ];
+
+    const boundsList = group.items.map((it) => getDaysBounds(it));
+    const minDays = Math.min(...boundsList.map((b) => b.minDays));
+    const maxDays = Math.max(...boundsList.map((b) => b.maxDays));
+
+    const daysStr = minDays === maxDays ? `${minDays}` : `${minDays} - ${maxDays}`;
+    const varietyStr = varieties.join(', ');
+
+    result.push({
+      variety: varietyStr,
+      days: daysStr,
+      days_lower: minDays,
+      days_upper: maxDays,
+      water: group.water,
+      probabilities: group.probabilities,
+    });
+  }
+
+  result.sort((a, b) => {
+    const aBounds = getDaysBounds(a);
+    const bBounds = getDaysBounds(b);
+
+    if (aBounds.midpoint !== bBounds.midpoint) {
+      return aBounds.midpoint - bBounds.midpoint;
+    }
+    if (aBounds.minDays !== bBounds.minDays) {
+      return aBounds.minDays - bBounds.minDays;
+    }
+    return a.variety.localeCompare(b.variety);
+  });
+
+  return result;
+}


### PR DESCRIPTION
## Developer Summary

> Info for reviewer, e.g. use of ai, pain points/challenges, discussion points for monthly dev call

## Related Issues

> Link any related issues (e.g., `Closes #[issue_number]`, `Relates to #[issue_number]`)

## Screenshots / Videos
**Screenshot** - Crops with identical days to maturity and water requirement are now grouped to reduce number of entries displayed in table

<img width="747" height="460" alt="image" src="https://github.com/user-attachments/assets/427dcade-6424-430d-9d38-6e9f5f57a230" />


## AI Summary

> Will be generated on PR open. Regenerate by typing comment `/describe` in PR
> More info at https://docs.pr-agent.ai/tools/describe/

### Description

### 🤖 Generated by PR Agent at dce97be1b62304b772fb6e287a8b1561a65b84a2

- Add crop variety grouping utility functions
- Group matching varieties into single table rows
- Refactor components to use shared grouping logic
- Expand tests for grouping and sorting


### Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>probability-table.utils.ts</strong><dd><code>New grouping and sorting utility functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-tools/crop-probability-tool/src/app/utils/probability-table.utils.ts

<ul><li>Added <code>getDaysBounds</code> to extract numeric days min/max/midpoint<br> <li> Added <code>groupAndSortCropDataItems</code> to group items by water/probability <br>match<br> <li> Grouped items merge variety names and compute combined days range<br> <li> Sorts grouped rows by days midpoint ascending</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/672/files#diff-0fb8260b64585f97cea45527c1d789835ba0ff2ae10dc3acbdbc9a43e383a6fc">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Extend crop data item model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-tools/crop-probability-tool/src/app/models/index.ts

<ul><li>Added optional <code>days_lower</code> and <code>days_upper</code> numeric fields<br> <li> Enables robust bounds handling for grouping logic</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/672/files#diff-320794c933951df229ff168d6a10d5781518d8db8fe4bdde6c8744d6e1210be5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>crop-probability-table.component.ts</strong><dd><code>Wire component to grouping utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-tools/crop-probability-tool/src/app/components/crop-probability-table/crop-probability-table.component.ts

<ul><li>Uses new <code>groupAndSortCropDataItems</code> utility<br> <li> Updates rowspan calculation to use grouped length<br> <li> Imports probability utils from tool library</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/672/files#diff-3c7526fbd6db34759b9a1da22c203c3b32bdcba6c7d712832f28f0c6346d4be8">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>probability.utils.ts</strong><dd><code>Refactor dashboard table to grouped output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-apps/dashboard/src/app/modules/crop-information/utils/probability.utils.ts

<ul><li>Removed inline sort logic in favour of grouping utility<br> <li> Populates new <code>days_lower</code>/<code>days_upper</code> on table entries<br> <li> Removed legacy HACK/TODO comments</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/672/files#diff-8414af574b2ba6caad032efb305af13b6c9e24895f741c32281e94897ef21e01">+5/-20</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crop-probability-table.component.spec.ts</strong><dd><code>Update spec to standalone with grouping test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-tools/crop-probability-tool/src/app/components/crop-probability-table/crop-probability-table.component.spec.ts

<ul><li>Migrated to standalone component test setup<br> <li> Added http/router/translate providers<br> <li> Added test verifying grouping and sorting output</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/672/files#diff-aec3781c3054a966005f463c33577303a1ac8b245f2a5d11b602a5b61f157a6b">+59/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>probability.utils.spec.ts</strong><dd><code>Add unit tests for grouping utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-apps/dashboard/src/app/modules/crop-information/utils/probability.utils.spec.ts

<ul><li>Added tests for <code>getDaysBounds</code> numeric and string fallback<br> <li> Added tests for <code>groupAndSortCropDataItems</code> grouping behaviour<br> <li> Added tests verifying midpoint-based sort ordering</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/672/files#diff-7eeff1bf37f61ed69df7df34c69481dcf168d3c5f3a3f73ff56ff6c28bb3a409">+94/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

### Diagram


```mermaid
flowchart LR
  A["IStationCropDataItem"] --> B["getDaysBounds"]
  C["Crop Items"] --> D["groupAndSortCropDataItems"]
  B --> D
  D --> E["CropProbabilityTableComponent"]
  D --> F["probability.utils.generateTable"]
  E --> G["Table Rows"]
  F --> G
```