### PR TITLE
fix: all null maturity period

### DIFF
--- a/apps/picsa-apps/dashboard/src/app/modules/crop-information/pages/variety/details/components/variety-form/variety-form.component.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/crop-information/pages/variety/details/components/variety-form/variety-form.component.ts
@@ -26,7 +26,7 @@ export class DashboardCropVarietyFormComponent {
     id: new FormControl(), // populated by server or on edit
     crop: ['', Validators.required],
     variety: ['', Validators.required],
-    maturity_period: ['', Validators.required],
+    maturity_period: new FormControl<string | null>(null),
     days_lower: [0, PICSAFormValidators.minMax(1, 1000)],
     days_upper: [0, PICSAFormValidators.minMax(1, 1000)],
     additional_info: new FormControl<string | null>(null),

--- a/apps/picsa-server/supabase/migrations/20260808091500_allow_null_maturity_period.sql
+++ b/apps/picsa-server/supabase/migrations/20260808091500_allow_null_maturity_period.sql
@@ -1,0 +1,2 @@
+-- Allow maturity_period to be NULL in public.crop_data
+ALTER TABLE public.crop_data ALTER COLUMN maturity_period DROP NOT NULL;

--- a/apps/picsa-server/supabase/types/db.types.ts
+++ b/apps/picsa-server/supabase/types/db.types.ts
@@ -351,7 +351,7 @@ export type Database = {
           days_lower: number;
           days_upper: number;
           id: string;
-          maturity_period: string;
+          maturity_period: string | null;
           updated_at: string;
           variety: string;
         };
@@ -364,7 +364,7 @@ export type Database = {
           days_lower: number;
           days_upper: number;
           id?: string;
-          maturity_period: string;
+          maturity_period?: string | null;
           updated_at?: string;
           variety: string;
         };
@@ -377,7 +377,7 @@ export type Database = {
           days_lower?: number;
           days_upper?: number;
           id?: string;
-          maturity_period?: string;
+          maturity_period?: string | null;
           updated_at?: string;
           variety?: string;
         };

--- a/apps/picsa-tools/crop-probability-tool/src/app/app.component.spec.ts
+++ b/apps/picsa-tools/crop-probability-tool/src/app/app.component.spec.ts
@@ -1,33 +1,26 @@
+import { provideHttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 
-import { AppComponent } from './app.component';
-import { NxWelcomeComponent } from './nx-welcome.component';
+import { PicsaCropProbabilityTool } from './app.component';
 
-describe('AppComponent', () => {
+describe('PicsaCropProbabilityTool', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      declarations: [AppComponent, NxWelcomeComponent],
+      imports: [PicsaCropProbabilityTool],
+      providers: [provideHttpClient(), provideRouter([])],
     }).compileComponents();
   });
 
   it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
+    const fixture = TestBed.createComponent(PicsaCropProbabilityTool);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title 'picsa-tools-crop-probability-tool'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
+  it(`should have as title 'crop-probability-tool'`, () => {
+    const fixture = TestBed.createComponent(PicsaCropProbabilityTool);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('picsa-tools-crop-probability-tool');
-  });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Welcome picsa-tools-crop-probability-tool');
+    expect(app.title).toEqual('crop-probability-tool');
   });
 });

--- a/apps/picsa-tools/crop-probability-tool/src/app/pages/home/home.component.spec.ts
+++ b/apps/picsa-tools/crop-probability-tool/src/app/pages/home/home.component.spec.ts
@@ -1,4 +1,8 @@
+import { provideHttpClient } from '@angular/common/http';
+import { importProvidersFrom } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { PicsaTranslateModule } from '@picsa/i18n';
 
 import { HomeComponent } from './home.component';
 
@@ -8,7 +12,8 @@ describe('HomeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [HomeComponent],
+      imports: [HomeComponent],
+      providers: [provideHttpClient(), provideRouter([]), importProvidersFrom(PicsaTranslateModule.forRoot())],
     }).compileComponents();
 
     fixture = TestBed.createComponent(HomeComponent);


### PR DESCRIPTION
## Developer Summary

> Info for reviewer, e.g. use of ai, pain points/challenges, discussion points for monthly dev call

## Related Issues

> Link any related issues (e.g., `Closes #[issue_number]`, `Relates to #[issue_number]`)

## Screenshots / Videos

> Include at least 1-2 screenshots of videos if visual changes

---

## AI Summary

> Will be generated on PR open. Regenerate by typing comment `/describe` in PR
> More info at https://docs.pr-agent.ai/tools/describe/

### Description

### 🤖 Generated by PR Agent at 6a1be55e6dd68c5322c8f079b91605022a53fda3

- Allow null `maturity_period` in crop data form and DB schema
- Add SQL migration to drop NOT NULL constraint on `maturity_period`
- Update Supabase TypeScript types to reflect nullable column
- Modernize crop-probability-tool component tests


### Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variety-form.component.ts</strong><dd><code>Allow null maturity period in variety form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-apps/dashboard/src/app/modules/crop-information/pages/variety/details/components/variety-form/variety-form.component.ts

<ul><li>Changed <code>maturity_period</code> form control from required string to nullable <br><code>FormControl<string | null>(null)</code><br> <li> Removed <code>Validators.required</code> from <code>maturity_period</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/673/files#diff-08b07670364e338b708c558702a5085afaf94b840de8bb7b62666f2d155c9227">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>db.types.ts</strong><dd><code>Update db types for nullable maturity period</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-server/supabase/types/db.types.ts

<ul><li>Updated <code>crop_data</code> Row type: <code>maturity_period</code> now <code>string | null</code><br> <li> Updated <code>crop_data</code> Insert type: <code>maturity_period</code> now optional and <br>nullable<br> <li> Updated <code>crop_data</code> Update type: <code>maturity_period</code> now optional and <br>nullable</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/673/files#diff-9b3b2ea15bcdca4f9278a4dd3fda22494391a21e2bc05e3e685fc5d254d9de0f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>20260808091500_allow_null_maturity_period.sql</strong><dd><code>Add migration to allow null maturity period</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-server/supabase/migrations/20260808091500_allow_null_maturity_period.sql

<ul><li>New migration dropping NOT NULL constraint on <br><code>public.crop_data.maturity_period</code></ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/673/files#diff-3add50436c0173dc052de43223a1808305f8215105c74353f78e6e4b2ac5e86d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.component.spec.ts</strong><dd><code>Modernize app component spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-tools/crop-probability-tool/src/app/app.component.spec.ts

<ul><li>Renamed test suite from <code>AppComponent</code> to <code>PicsaCropProbabilityTool</code><br> <li> Replaced <code>RouterTestingModule</code> with <code>provideRouter([])</code> and <br><code>provideHttpClient()</code><br> <li> Removed <code>NxWelcomeComponent</code> references and updated title expectation</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/673/files#diff-feac9c47c10de073c2fd01d3d1ef3ededc004da04768c2f1752fe52077eedb3f">+10/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>home.component.spec.ts</strong><dd><code>Modernize home component spec providers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-tools/crop-probability-tool/src/app/pages/home/home.component.spec.ts

<ul><li>Switched <code>declarations</code> to <code>imports</code> for standalone component<br> <li> Added providers for <code>provideHttpClient</code>, <code>provideRouter</code>, and <br><code>PicsaTranslateModule</code></ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/673/files#diff-3ffb6dcf7bdb2c3ecb959b093dcef2e6847e651e3c7e4ac131e6e7e5b8e1c09a">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

### Diagram


```mermaid
flowchart LR
  A["variety-form.component.ts"] --> B["FormControl<string | null>"]
  C["SQL Migration"] --> D["DROP NOT NULL on maturity_period"]
  E["db.types.ts"] --> F["maturity_period: string | null"]
  B --> G["Nullable maturity period"]
  D --> G
  F --> G
```