### PR TITLE
fix: crop water interpolation

### DIFF
--- a/apps/picsa-apps/dashboard/src/app/modules/crop-information/utils/probability.utils.spec.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/crop-information/utils/probability.utils.spec.ts
@@ -4,7 +4,12 @@ import {
   groupAndSortCropDataItems,
 } from '@picsa/crop-probability/src/app/utils/probability-table.utils';
 
-import { findSurroundingKeys, getCropSuccessProbability, linearInterpolationStrategy } from './probability.utils';
+import {
+  findSurroundingKeys,
+  getCropSuccessProbability,
+  interpolateValue,
+  linearInterpolationStrategy,
+} from './probability.utils';
 
 describe('probability.utils', () => {
   describe('findSurroundingKeys', () => {
@@ -39,6 +44,24 @@ describe('probability.utils', () => {
     });
   });
 
+  describe('interpolateValue', () => {
+    it('should interpolate using strategy when both values are numbers', () => {
+      expect(interpolateValue(325, 300, 350, 0.4, 0.8)).toBeCloseTo(0.6);
+    });
+
+    it('should fall back to valLower when valUpper is undefined', () => {
+      expect(interpolateValue(325, 300, 350, 0.4, undefined)).toBe(0.4);
+    });
+
+    it('should fall back to valUpper when valLower is undefined', () => {
+      expect(interpolateValue(325, 300, 350, undefined, 0.8)).toBe(0.8);
+    });
+
+    it('should return undefined when both values are undefined', () => {
+      expect(interpolateValue(325, 300, 350, undefined, undefined)).toBeUndefined();
+    });
+  });
+
   describe('getCropSuccessProbability', () => {
     const mockHashmap = {
       250: {
@@ -56,8 +79,8 @@ describe('probability.utils', () => {
       expect(result[1]).toBeCloseTo(0.6);
     });
 
-    it('should return undefined if water requirement does not exist', () => {
-      const result = getCropSuccessProbability(500, 60, [100, 200], mockHashmap);
+    it('should return undefined if probability hashmap is empty', () => {
+      const result = getCropSuccessProbability(500, 60, [100, 200], {});
       expect(result).toEqual([undefined, undefined]);
     });
 
@@ -71,6 +94,45 @@ describe('probability.utils', () => {
       const result = getCropSuccessProbability(250, 60, [100, 200], sparseHashmap);
       expect(result[0]).toBe(0.2);
       expect(result[1]).toBe(0.8);
+    });
+
+    it('should interpolate successfully for 50mm increment lookup tables (weighted average over water)', () => {
+      // Lookup table available only in 50mm increments: 300 and 350
+      const hashmap50mm = {
+        300: {
+          60: { 100: 0.4, 200: 0.6 },
+        },
+        350: {
+          60: { 100: 0.8, 200: 1.0 },
+        },
+      };
+      // Target water requirement is 325 (midpoint between 300 and 350)
+      const resultMidpoint = getCropSuccessProbability(325, 60, [100, 200], hashmap50mm);
+      expect(resultMidpoint[0]).toBeCloseTo(0.6);
+      expect(resultMidpoint[1]).toBeCloseTo(0.8);
+
+      // Target water requirement is 320 (40% between 300 and 350)
+      const resultFraction = getCropSuccessProbability(320, 60, [100, 200], hashmap50mm);
+      expect(resultFraction[0]).toBeCloseTo(0.56);
+      expect(resultFraction[1]).toBeCloseTo(0.76);
+    });
+
+    it('should cap at nearest water boundary when water requirement is out of bounds', () => {
+      const hashmap50mm = {
+        300: {
+          60: { 100: 0.4, 200: 0.6 },
+        },
+        350: {
+          60: { 100: 0.8, 200: 1.0 },
+        },
+      };
+      // Below min key (250 < 300) -> returns probabilities for 300
+      const resultBelow = getCropSuccessProbability(250, 60, [100, 200], hashmap50mm);
+      expect(resultBelow).toEqual([0.4, 0.6]);
+
+      // Above max key (400 > 350) -> returns probabilities for 350
+      const resultAbove = getCropSuccessProbability(400, 60, [100, 200], hashmap50mm);
+      expect(resultAbove).toEqual([0.8, 1.0]);
     });
   });
 

--- a/apps/picsa-apps/dashboard/src/app/modules/crop-information/utils/probability.utils.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/crop-information/utils/probability.utils.ts
@@ -147,6 +147,24 @@ export function generateProbabilityHashmap(entries: ICropSuccessEntry[]): IProba
 }
 
 /**
+ * Helper to interpolate between lower and upper boundary values.
+ * Falls back to available boundary value if one is missing (sparse data).
+ */
+export function interpolateValue(
+  target: number,
+  lowerKey: number,
+  upperKey: number,
+  valLower: number | undefined,
+  valUpper: number | undefined,
+  strategy: IProbabilityInterpolationStrategy = linearInterpolationStrategy,
+): number | undefined {
+  if (typeof valLower === 'number' && typeof valUpper === 'number') {
+    return strategy(target, lowerKey, upperKey, valLower, valUpper);
+  }
+  return valLower ?? valUpper;
+}
+
+/**
  * Fetches and interpolates the crop success probability for a given water requirement and plant length.
  * Decouples lookup and math strategies, supporting nearest-neighbor/clipping bounds and sparse database fallbacks.
  */
@@ -157,46 +175,48 @@ export function getCropSuccessProbability(
   probabilityHashmap: IProbabilityHashmap,
   strategy: IProbabilityInterpolationStrategy = linearInterpolationStrategy,
 ): (number | undefined)[] {
-  const waterRounded = roundToNearest(water, WATER_REQUIREMENT_ROUNDING);
-  const targetDays = days;
-  const probabilities: (number | undefined)[] = [];
+  const waterKeys = Object.keys(probabilityHashmap).map(Number);
+  if (waterKeys.length === 0) {
+    return new Array(plantDates.length).fill(undefined);
+  }
 
-  const waterEntry = probabilityHashmap[waterRounded];
-  if (waterEntry) {
+  const { lower: lowerWater, upper: upperWater } = findSurroundingKeys(water, waterKeys);
+
+  const getProbabilitiesForWaterKey = (wKey: number): (number | undefined)[] => {
+    const waterEntry = probabilityHashmap[wKey];
+    if (!waterEntry) {
+      return new Array(plantDates.length).fill(undefined);
+    }
+
     const plantLengths = Object.keys(waterEntry).map(Number);
     if (plantLengths.length === 0) {
       return new Array(plantDates.length).fill(undefined);
     }
 
-    // Find the surrounding keys directly above and below targetDays
-    const { lower, upper } = findSurroundingKeys(targetDays, plantLengths);
+    const { lower: lowerDays, upper: upperDays } = findSurroundingKeys(days, plantLengths);
 
-    const lowerEntry = waterEntry[lower];
-    const upperEntry = waterEntry[upper];
+    return plantDates.map((date) =>
+      interpolateValue(
+        days,
+        lowerDays,
+        upperDays,
+        waterEntry[lowerDays]?.[date],
+        waterEntry[upperDays]?.[date],
+        strategy,
+      ),
+    );
+  };
 
-    for (const date of plantDates) {
-      const probLower = lowerEntry?.[date];
-      const probUpper = upperEntry?.[date];
-
-      // Interpolate if both values are valid numbers, otherwise fall back to nearest boundary (sparse data)
-      if (typeof probLower === 'number' && typeof probUpper === 'number') {
-        const interpolated = strategy(targetDays, lower, upper, probLower, probUpper);
-        probabilities.push(interpolated);
-      } else if (typeof probLower === 'number') {
-        probabilities.push(probLower);
-      } else if (typeof probUpper === 'number') {
-        probabilities.push(probUpper);
-      } else {
-        probabilities.push(undefined);
-      }
-    }
-  } else {
-    for (let i = 0; i < plantDates.length; i++) {
-      probabilities.push(undefined);
-    }
+  if (lowerWater === upperWater) {
+    return getProbabilitiesForWaterKey(lowerWater);
   }
 
-  return probabilities;
+  const probsLowerWater = getProbabilitiesForWaterKey(lowerWater);
+  const probsUpperWater = getProbabilitiesForWaterKey(upperWater);
+
+  return plantDates.map((_, i) =>
+    interpolateValue(water, lowerWater, upperWater, probsLowerWater[i], probsUpperWater[i], strategy),
+  );
 }
 
 export function generateProbabilityEntryValues(

--- a/apps/picsa-apps/dashboard/src/app/modules/crop-information/utils/probability.utils.ts
+++ b/apps/picsa-apps/dashboard/src/app/modules/crop-information/utils/probability.utils.ts
@@ -158,6 +158,9 @@ export function interpolateValue(
   valUpper: number | undefined,
   strategy: IProbabilityInterpolationStrategy = linearInterpolationStrategy,
 ): number | undefined {
+  if (lowerKey === upperKey) {
+    return valLower ?? valUpper;
+  }
   if (typeof valLower === 'number' && typeof valUpper === 'number') {
     return strategy(target, lowerKey, upperKey, valLower, valUpper);
   }


### PR DESCRIPTION
## Developer Summary

Fix case where mw Nkhotakota probability table only includes 50mm outputs.
This should be fixed by climate data team in the future, but temporary measure to ensure tables can still be produced

## Related Issues

> Link any related issues (e.g., `Closes #[issue_number]`, `Relates to #[issue_number]`)

## Screenshots / Videos

> Include at least 1-2 screenshots of videos if visual changes

---

## AI Summary

> Will be generated on PR open. Regenerate by typing comment `/describe` in PR
> More info at https://docs.pr-agent.ai/tools/describe/

### Description

### 🤖 Generated by PR Agent at 0c96254bbd608ef1c5aa8d2d79155e0214a34098

- Fix crop water interpolation to interpolate between water boundaries
- Add `interpolateValue` helper for sparse data fallback
- Cap water lookup at nearest boundary when out of bounds
- Add tests covering 50mm increment interpolation and boundary capping


### Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>probability.utils.ts</strong><dd><code>Refactor crop probability to interpolate water boundaries</code></dd></summary>
<hr>

apps/picsa-apps/dashboard/src/app/modules/crop-information/utils/probability.utils.ts

<ul><li>Added <code>interpolateValue</code> helper to centralize interpolation with <br>sparse-data fallback<br> <li> Refactored <code>getCropSuccessProbability</code> to interpolate across water <br>requirement keys using <code>findSurroundingKeys</code><br> <li> Added empty-hashmap guard returning array of undefined values<br> <li> Capped water lookup at nearest boundary when target is out of bounds</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/674/files#diff-8414af574b2ba6caad032efb305af13b6c9e24895f741c32281e94897ef21e01">+52/-32</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>probability.utils.spec.ts</strong><dd><code>Add tests for water interpolation and boundary capping</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/picsa-apps/dashboard/src/app/modules/crop-information/utils/probability.utils.spec.ts

<ul><li>Added test suite for new <code>interpolateValue</code> helper covering both-number, <br>single-boundary, and undefined cases<br> <li> Updated existing test to use empty hashmap instead of missing water <br>key<br> <li> Added tests for 50mm increment water interpolation (midpoint and <br>fractional)<br> <li> Added test for out-of-bounds water capping behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/674/files#diff-7eeff1bf37f61ed69df7df34c69481dcf168d3c5f3a3f73ff56ff6c28bb3a409">+65/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

### Diagram


```mermaid
flowchart LR
  A["Water Lookup (rounded)"] -- "fix" --> B["Water Interpolation"]
  B --> C["findSurroundingKeys"]
  B --> D["interpolateValue helper"]
  B --> E["Cap at nearest boundary"]
```