### PR TITLE
refactor(climate-tool): el nino print mode and tidying

### DIFF
--- a/apps/picsa-tools/climate-tool/src/app/components/chart-tools/base-tool.component.ts
+++ b/apps/picsa-tools/climate-tool/src/app/components/chart-tools/base-tool.component.ts
@@ -28,6 +28,14 @@ export interface IPointStyle {
   opacity?: number;
 }
 
+export interface ILegendItem {
+  label: string;
+  shape: PointShape;
+  fill: string;
+  stroke?: string;
+  strokeWidth?: number;
+}
+
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '',
@@ -74,6 +82,11 @@ export abstract class BaseChartToolComponent {
     return undefined;
   }
 
+  /** Override to draw a custom legend directly on the chart SVG canvas */
+  public getLegendItems(): ILegendItem[] | undefined {
+    return undefined;
+  }
+
   public formatTooltipRow(year: number): ITooltipExtraRow | undefined {
     return undefined;
   }
@@ -86,9 +99,11 @@ export abstract class BaseChartToolComponent {
     if (!data?.length || !def) return values;
 
     const xVar = def.xVar || 'Year';
+    const isValidVal = (val: any): boolean => typeof val === 'number' && Number.isFinite(val);
+
     for (const row of data) {
       const x = row[xVar] as number;
-      if (Number.isFinite(x) && (def.keys || []).some((key) => Number.isFinite(row[key]))) {
+      if (isValidVal(x) && (def.keys || []).some((key) => isValidVal(row[key]))) {
         values.add(x);
       }
     }
@@ -97,7 +112,8 @@ export abstract class BaseChartToolComponent {
 
   /** Shared guard excluding tool series and x values without data */
   protected isDecoratable(d: DataPoint): d is DataPoint & { x: number } {
-    if (typeof d?.x !== 'number') return false;
+    if (typeof d?.x !== 'number' || !Number.isFinite(d.x)) return false;
+    if (typeof d?.value !== 'number' || !Number.isFinite(d.value)) return false;
     if (d.id && TOOL_SERIES_IDS.includes(d.id)) return false;
     return this.validXValues().has(d.x);
   }

--- a/apps/picsa-tools/climate-tool/src/app/components/chart-tools/base-tool.component.ts
+++ b/apps/picsa-tools/climate-tool/src/app/components/chart-tools/base-tool.component.ts
@@ -11,6 +11,23 @@ export interface ITooltipExtraRow {
   color: string;
 }
 
+export type PointShape = 'circle' | 'square' | 'triangle' | 'diamond';
+
+/**
+ * Declarative marker definition for a single data point.
+ * NOTE - paint properties are applied as inline SVG attributes (not CSS) so that
+ * markers survive PNG export via `svgToPngBlob`.
+ */
+export interface IPointStyle {
+  shape: PointShape;
+  /** radius / half-extent in px, at the default point scale */
+  size: number;
+  fill: string;
+  stroke?: string;
+  strokeWidth?: number;
+  opacity?: number;
+}
+
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '',
@@ -20,15 +37,19 @@ export abstract class BaseChartToolComponent {
   protected toolService = inject(ClimateToolService);
   protected destroyRef = inject(DestroyRef);
 
-  /** Protected reactive signals & streams exposing chart data/config to derived tools */
   protected readonly chartDefinition = computed(() => this.chartService.chartDefinition());
   protected readonly chartSeriesData = computed(() => this.chartService.chartSeriesData());
   protected readonly stationData = computed(() => this.chartService.stationData());
   protected readonly chartConfig = computed(() => this.chartService.chartConfig());
   protected readonly chartRendered$ = this.chartService.chartRendered$;
 
+  /**
+   * Set true in subclasses that implement `getPointStyle`, so the chart service
+   * knows to render the custom marker overlay and hide C3's default circles.
+   */
+  public readonly usesPointOverlay: boolean = false;
+
   constructor() {
-    // Register this tool instance as the active tool handler on ClimateChartService
     this.chartService.activeToolHandler.set(this);
 
     this.destroyRef.onDestroy(() => {
@@ -48,8 +69,37 @@ export abstract class BaseChartToolComponent {
     return undefined;
   }
 
+  /** Override to draw a custom marker in place of C3's default circle */
+  public getPointStyle(d: DataPoint): IPointStyle | undefined {
+    return undefined;
+  }
+
   public formatTooltipRow(year: number): ITooltipExtraRow | undefined {
     return undefined;
+  }
+
+  /** Set of x values (usually years) having at least one finite value on the active chart */
+  protected readonly validXValues = computed(() => {
+    const data = this.stationData();
+    const def = this.chartDefinition();
+    const values = new Set<number>();
+    if (!data?.length || !def) return values;
+
+    const xVar = def.xVar || 'Year';
+    for (const row of data) {
+      const x = row[xVar] as number;
+      if (Number.isFinite(x) && (def.keys || []).some((key) => Number.isFinite(row[key]))) {
+        values.add(x);
+      }
+    }
+    return values;
+  });
+
+  /** Shared guard excluding tool series and x values without data */
+  protected isDecoratable(d: DataPoint): d is DataPoint & { x: number } {
+    if (typeof d?.x !== 'number') return false;
+    if (d.id && TOOL_SERIES_IDS.includes(d.id)) return false;
+    return this.validXValues().has(d.x);
   }
 
   /** Helper method for tools to add horizontal lines to the chart */
@@ -67,9 +117,6 @@ export abstract class BaseChartToolComponent {
     return this.chartService.convertDateToDayNumber(date);
   }
 
-  /**
-   * Unregisters this tool instance from ClimateChartService and executes per-tool cleanup.
-   */
   protected cleanupToolState() {
     if (this.chartService.activeToolHandler() === this) {
       this.chartService.activeToolHandler.set(undefined);

--- a/apps/picsa-tools/climate-tool/src/app/components/chart-tools/el-nino-tool/el-nino-tool.component.html
+++ b/apps/picsa-tools/climate-tool/src/app/components/chart-tools/el-nino-tool/el-nino-tool.component.html
@@ -2,12 +2,7 @@
   @for (item of legendItems; track item.label) {
     <div class="legend-item">
       <svg class="marker" viewBox="-14 -14 28 28" aria-hidden="true">
-        <path
-          [attr.d]="item.path"
-          [attr.fill]="item.color"
-          [attr.stroke]="item.stroke || 'none'"
-          stroke-width="1.5"
-        />
+        <path [attr.d]="item.path" [attr.fill]="item.color" [attr.stroke]="item.stroke || 'none'" stroke-width="1.5" />
       </svg>
       <span class="label">{{ item.label | translate }}</span>
     </div>

--- a/apps/picsa-tools/climate-tool/src/app/components/chart-tools/el-nino-tool/el-nino-tool.component.html
+++ b/apps/picsa-tools/climate-tool/src/app/components/chart-tools/el-nino-tool/el-nino-tool.component.html
@@ -1,10 +1,15 @@
-<div class="el-nino-legend" [ngStyle]="styles">
-  <div class="legend-item">
-    <span class="marker triangle-marker"></span>
-    <span class="label">{{ 'El Niño' | translate }}</span>
-  </div>
-  <div class="legend-item">
-    <span class="marker square-marker"></span>
-    <span class="label">{{ 'La Niña' | translate }}</span>
-  </div>
+<div class="el-nino-legend">
+  @for (item of legendItems; track item.label) {
+    <div class="legend-item">
+      <svg class="marker" viewBox="-14 -14 28 28" aria-hidden="true">
+        <path
+          [attr.d]="item.path"
+          [attr.fill]="item.color"
+          [attr.stroke]="item.stroke || 'none'"
+          stroke-width="1.5"
+        />
+      </svg>
+      <span class="label">{{ item.label | translate }}</span>
+    </div>
+  }
 </div>

--- a/apps/picsa-tools/climate-tool/src/app/components/chart-tools/el-nino-tool/el-nino-tool.component.scss
+++ b/apps/picsa-tools/climate-tool/src/app/components/chart-tools/el-nino-tool/el-nino-tool.component.scss
@@ -1,11 +1,20 @@
 :host {
   display: block;
 }
+// reference to hardcoded colors used in .ts file for quick view only
+.ts {
+  --el-nino-fill: #d4802b;
+  --el-nino-stroke: #b86b1f;
+  --la-nina-fill: #13599e;
+  --la-nina-stroke: #0d4277;
+  --neutral-fill: #9e9e9e;
+}
+
 .el-nino-legend {
   display: flex;
+  gap: 1rem;
   align-items: center;
   justify-content: center;
-  gap: 24px;
   padding: 8px 16px;
   background-color: #f5f5f5;
   border-radius: 6px;
@@ -16,22 +25,12 @@
 
 .legend-item {
   display: flex;
+  gap: 0.35rem;
   align-items: center;
-  gap: 8px;
 }
 
 .marker {
-  display: inline-block;
-  width: 14px;
-  height: 14px;
-}
-
-.triangle-marker {
-  background-color: var(--el-nino-color);
-  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
-}
-
-.square-marker {
-  background-color: var(--la-nina-color);
-  border-radius: 0px;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 auto;
 }

--- a/apps/picsa-tools/climate-tool/src/app/components/chart-tools/el-nino-tool/el-nino-tool.component.ts
+++ b/apps/picsa-tools/climate-tool/src/app/components/chart-tools/el-nino-tool/el-nino-tool.component.ts
@@ -1,296 +1,53 @@
-import { NgStyle } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, effect, HostListener } from '@angular/core';
-import {
-  EL_NINO_COLOR,
-  EL_NINO_YEARS,
-  ENSO_NEUTRAL_COLOR,
-  LA_NINA_COLOR,
-  LA_NINA_YEARS,
-} from '@picsa/data/climate/tool_definitions';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { EL_NINO_YEARS, LA_NINA_YEARS } from '@picsa/data/climate/tool_definitions';
 import { PicsaTranslateModule } from '@picsa/i18n';
 import { DataPoint } from 'c3';
 
-import { BaseChartToolComponent, ITooltipExtraRow, TOOL_SERIES_IDS } from '../base-tool.component';
+import { getShapePath } from '../../../utils/chart-point-overlay';
+import { BaseChartToolComponent, IPointStyle, ITooltipExtraRow } from '../base-tool.component';
+
+const EL_NINO_SET = new Set(EL_NINO_YEARS);
+const LA_NINA_SET = new Set(LA_NINA_YEARS);
+
+type EnsoPhase = 'elNino' | 'laNina' | 'neutral';
+
+const PHASE_STYLE: Record<EnsoPhase, IPointStyle> = {
+  elNino: { shape: 'triangle', size: 12, fill: '#d4802b', stroke: '#b86b1f', strokeWidth: 1.5 },
+  laNina: { shape: 'square', size: 8, fill: '#13599e', stroke: '#0d4277', strokeWidth: 1.5 },
+  neutral: { shape: 'circle', size: 4, fill: '#9e9e9e', opacity: 0.6 },
+};
+
+const phaseOf = (year: number): EnsoPhase =>
+  EL_NINO_SET.has(year) ? 'elNino' : LA_NINA_SET.has(year) ? 'laNina' : 'neutral';
 
 @Component({
   selector: 'climate-el-nino-tool',
   templateUrl: './el-nino-tool.component.html',
   styleUrls: ['./el-nino-tool.component.scss'],
-  imports: [PicsaTranslateModule, NgStyle],
+  imports: [PicsaTranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ElNinoToolComponent extends BaseChartToolComponent {
-  private elNinoSet = new Set(EL_NINO_YEARS);
-  private laNinaSet = new Set(LA_NINA_YEARS);
+  public override readonly usesPointOverlay = true;
 
-  private elNinoLabel = 'El Niño';
-  private laNinaLabel = 'La Niña';
+  /** Legend entries, sharing marker geometry with the chart overlay */
+  public readonly legendItems = (['elNino', 'laNina'] as const).map((phase) => ({
+    label: phase === 'elNino' ? 'El Niño' : 'La Niña',
+    path: getShapePath(PHASE_STYLE[phase].shape, PHASE_STYLE[phase].size),
+    color: PHASE_STYLE[phase].fill,
+    stroke: PHASE_STYLE[phase].stroke,
+  }));
 
-  // Assign color variables from data
-  public readonly styles = { '--el-nino-color': EL_NINO_COLOR, '--la-nina-color': LA_NINA_COLOR };
-
-  /** Cache set of valid years with data using a computed signal */
-  protected readonly validYearsWithData = computed(() => {
-    const data = this.stationData();
-    const chartDef = this.chartDefinition();
-    if (!data || data.length === 0 || !chartDef) return new Set<number>();
-
-    const xVar = chartDef.xVar || 'Year';
-    const dataKeys = chartDef.keys || [];
-    const validYears = new Set<number>();
-
-    for (const d of data) {
-      const year = d[xVar] as number;
-      if (typeof year === 'number' && !isNaN(year)) {
-        const hasValue = dataKeys.some((key) => {
-          const val = d[key];
-          return val !== null && val !== undefined && (val as any) !== '' && typeof val === 'number' && !isNaN(val);
-        });
-
-        if (hasValue) {
-          validYears.add(year);
-        }
-      }
-    }
-
-    return validYears;
-  });
-
-  constructor() {
-    super();
-
-    // Apply custom SVG shapes whenever chart is rendered or updated
-    const sub = this.chartRendered$.subscribe(() => {
-      this.applyPointShapes();
-    });
-
-    // Reactively trigger shape application on configuration/data change
-    effect(() => {
-      const config = this.chartConfig();
-      if (config) {
-        setTimeout(() => this.applyPointShapes(), 100);
-      }
-    });
-
-    this.destroyRef.onDestroy(() => {
-      sub.unsubscribe();
-    });
+  public override getPointStyle(d: DataPoint): IPointStyle | undefined {
+    if (!this.isDecoratable(d)) return undefined;
+    return PHASE_STYLE[phaseOf(d.x)];
   }
 
-  @HostListener('window:resize', [])
-  onWindowResize() {
-    setTimeout(() => this.applyPointShapes(), 50);
-  }
-
-  public override getPointColour(d: any): string | undefined {
-    if (d && typeof d.x === 'number') {
-      if (d.id && TOOL_SERIES_IDS.includes(d.id)) return undefined;
-      const validYears = this.validYearsWithData();
-      if (!validYears.has(d.x)) {
-        return undefined; // Omit years without data
-      }
-      if (this.elNinoSet.has(d.x)) return EL_NINO_COLOR;
-      if (this.laNinaSet.has(d.x)) return LA_NINA_COLOR;
-      return ENSO_NEUTRAL_COLOR; // Grey out neutral years with valid data
-    }
-    return undefined;
-  }
-
-  // Point radius formatter: El Niño slightly larger = 12, La Niña = 8, Neutral strictly = 4
-  public override getPointRadius(d: DataPoint): number | undefined {
-    if (d && typeof d.x === 'number') {
-      if (d.id && TOOL_SERIES_IDS.includes(d.id)) return undefined;
-      const validYears = this.validYearsWithData();
-      if (!validYears.has(d.x)) {
-        return undefined; // Omit years without data
-      }
-      if (this.elNinoSet.has(d.x)) return 12;
-      if (this.laNinaSet.has(d.x)) return 8;
-      return 4; // Radius 4 for neutral years with valid data
-    }
-    return undefined;
-  }
-
-  // Tooltip pop-up row formatter (only for years with valid data)
   public override formatTooltipRow(year: number): ITooltipExtraRow | undefined {
-    const validYears = this.validYearsWithData();
-    if (!validYears.has(year)) {
-      return undefined; // Omit years without data
-    }
-    if (this.elNinoSet.has(year)) {
-      return { text: `▲ ${this.elNinoLabel}`, color: EL_NINO_COLOR };
-    }
-    if (this.laNinaSet.has(year)) {
-      return { text: `■ ${this.laNinaLabel}`, color: LA_NINA_COLOR };
-    }
+    if (!this.validXValues().has(year)) return undefined;
+    const phase = phaseOf(year);
+    if (phase === 'elNino') return { text: `▲ El Niño`, color: '#d4802b' };
+    if (phase === 'laNina') return { text: `■ La Niña`, color: '#13599e' };
     return undefined;
-  }
-
-  protected override onToolDestroy() {
-    this.clearPointShapes();
-  }
-
-  /** Calculate current SVG pixel coordinates for point data using C3 internal scale API or DOM attributes */
-  private getPointCoordinates(el: SVGElement, d: any): { cx: number; cy: number } | undefined {
-    const chartApi = (this.chartService.chartComponent?.chart as any)?.internal;
-    if (chartApi && typeof chartApi.x === 'function') {
-      try {
-        const cx = chartApi.x(d.x);
-        const cy = typeof chartApi.getYValue === 'function' ? chartApi.getYValue(d) : chartApi.y(d.value);
-        if (typeof cx === 'number' && !isNaN(cx) && typeof cy === 'number' && !isNaN(cy)) {
-          return { cx, cy };
-        }
-      } catch (e) {
-        // Fallback to DOM attributes
-      }
-    }
-
-    let cx = 0;
-    let cy = 0;
-
-    if (el.tagName === 'circle') {
-      cx = parseFloat(el.getAttribute('cx') || '0');
-      cy = parseFloat(el.getAttribute('cy') || '0');
-    } else if (el.tagName === 'rect') {
-      const x = parseFloat(el.getAttribute('x') || '0');
-      const y = parseFloat(el.getAttribute('y') || '0');
-      const w = parseFloat(el.getAttribute('width') || '0');
-      const h = parseFloat(el.getAttribute('height') || '0');
-      cx = x + w / 2;
-      cy = y + h / 2;
-    } else if (el.tagName === 'polygon') {
-      const origCx = el.getAttribute('data-cx');
-      const origCy = el.getAttribute('data-cy');
-      if (origCx && origCy) {
-        cx = parseFloat(origCx);
-        cy = parseFloat(origCy);
-      }
-    }
-
-    if (cx || cy) {
-      return { cx, cy };
-    }
-    return undefined;
-  }
-
-  private applyPointShapes() {
-    const svg = document.querySelector<SVGSVGElement>('#picsa_chart_svg');
-    if (!svg) return;
-
-    const validYears = this.validYearsWithData();
-
-    const points = svg.querySelectorAll<SVGElement>('.c3-circles .c3-circle');
-    points.forEach((el: any) => {
-      const d = el.__data__;
-      if (!d || typeof d.x !== 'number') return;
-
-      // Ignore points belonging to tool lines (LineTool, lowerTercile, upperTercile)
-      if (d.id && TOOL_SERIES_IDS.includes(d.id)) return;
-
-      const year = d.x;
-
-      // Omit years without valid data for the active chart
-      if (!validYears.has(year)) {
-        return;
-      }
-
-      const coords = this.getPointCoordinates(el, d);
-      if (!coords) return;
-      const { cx, cy } = coords;
-
-      if (this.elNinoSet.has(year)) {
-        // Red/Orange Triangle (larger marker)
-        const r = 12;
-        const pts = `${cx},${cy - r} ${cx - r * 0.866},${cy + r * 0.5} ${cx + r * 0.866},${cy + r * 0.5}`;
-
-        if (el.tagName === 'polygon') {
-          // Update in-place to avoid node recreation
-          el.setAttribute('points', pts);
-          el.setAttribute('data-cx', cx.toString());
-          el.setAttribute('data-cy', cy.toString());
-        } else {
-          const poly = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
-          poly.setAttribute('points', pts);
-          poly.setAttribute('data-cx', cx.toString());
-          poly.setAttribute('data-cy', cy.toString());
-          poly.setAttribute('class', 'c3-circle el-nino-point');
-          poly.setAttribute(
-            'style',
-            `fill: ${EL_NINO_COLOR} !important; stroke: #b86b1f !important; stroke-width: 1.5px !important;`,
-          );
-          (poly as any).__data__ = d;
-          el.parentNode?.replaceChild(poly, el);
-        }
-      } else if (this.laNinaSet.has(year)) {
-        // Blue Square marker
-        const size = 16;
-        const half = size / 2;
-        const rx = cx - half;
-        const ry = cy - half;
-
-        if (el.tagName === 'rect') {
-          // Update in-place to avoid node recreation
-          el.setAttribute('x', rx.toString());
-          el.setAttribute('y', ry.toString());
-        } else {
-          const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-          rect.setAttribute('x', rx.toString());
-          rect.setAttribute('y', ry.toString());
-          rect.setAttribute('width', size.toString());
-          rect.setAttribute('height', size.toString());
-          rect.setAttribute('class', 'c3-circle la-nina-point');
-          rect.setAttribute(
-            'style',
-            `fill: ${LA_NINA_COLOR} !important; stroke: #0d4277 !important; stroke-width: 1.5px !important;`,
-          );
-          (rect as any).__data__ = d;
-          el.parentNode?.replaceChild(rect, el);
-        }
-      } else {
-        // Grey Circle with radius 4 and NO border
-        if (el.tagName === 'circle') {
-          // Update in-place
-          el.setAttribute('cx', cx.toString());
-          el.setAttribute('cy', cy.toString());
-          el.setAttribute('r', '4');
-        } else {
-          const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-          circle.setAttribute('cx', cx.toString());
-          circle.setAttribute('cy', cy.toString());
-          circle.setAttribute('r', '4');
-          circle.setAttribute('class', 'c3-circle neutral-point');
-          circle.setAttribute(
-            'style',
-            `fill: ${ENSO_NEUTRAL_COLOR} !important; stroke: none !important; opacity: 0.6 !important;`,
-          );
-          (circle as any).__data__ = d;
-          el.parentNode?.replaceChild(circle, el);
-        }
-      }
-    });
-  }
-
-  private clearPointShapes() {
-    const svg = document.querySelector<SVGSVGElement>('#picsa_chart_svg');
-    if (!svg) return;
-
-    const points = svg.querySelectorAll<SVGElement>('.c3-circles .c3-circle');
-    points.forEach((el: any) => {
-      const d = el.__data__;
-      const coords = d ? this.getPointCoordinates(el, d) : undefined;
-      const cx = coords ? coords.cx : parseFloat(el.getAttribute('cx') || '0');
-      const cy = coords ? coords.cy : parseFloat(el.getAttribute('cy') || '0');
-
-      if (cx || cy) {
-        const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-        circle.setAttribute('cx', cx.toString());
-        circle.setAttribute('cy', cy.toString());
-        circle.setAttribute('r', '8');
-        circle.setAttribute('class', 'c3-circle');
-        circle.removeAttribute('style');
-        (circle as any).__data__ = el.__data__;
-        el.parentNode?.replaceChild(circle, el);
-      }
-    });
   }
 }

--- a/apps/picsa-tools/climate-tool/src/app/components/chart-tools/el-nino-tool/el-nino-tool.component.ts
+++ b/apps/picsa-tools/climate-tool/src/app/components/chart-tools/el-nino-tool/el-nino-tool.component.ts
@@ -4,14 +4,14 @@ import { PicsaTranslateModule } from '@picsa/i18n';
 import { DataPoint } from 'c3';
 
 import { getShapePath } from '../../../utils/chart-point-overlay';
-import { BaseChartToolComponent, IPointStyle, ITooltipExtraRow } from '../base-tool.component';
+import { BaseChartToolComponent, ILegendItem, IPointStyle, ITooltipExtraRow } from '../base-tool.component';
 
 const EL_NINO_SET = new Set(EL_NINO_YEARS);
 const LA_NINA_SET = new Set(LA_NINA_YEARS);
 
 type EnsoPhase = 'elNino' | 'laNina' | 'neutral';
 
-const PHASE_STYLE: Record<EnsoPhase, IPointStyle> = {
+const STYLES: Record<EnsoPhase, IPointStyle> = {
   elNino: { shape: 'triangle', size: 12, fill: '#d4802b', stroke: '#b86b1f', strokeWidth: 1.5 },
   laNina: { shape: 'square', size: 8, fill: '#13599e', stroke: '#0d4277', strokeWidth: 1.5 },
   neutral: { shape: 'circle', size: 4, fill: '#9e9e9e', opacity: 0.6 },
@@ -30,24 +30,30 @@ const phaseOf = (year: number): EnsoPhase =>
 export class ElNinoToolComponent extends BaseChartToolComponent {
   public override readonly usesPointOverlay = true;
 
-  /** Legend entries, sharing marker geometry with the chart overlay */
-  public readonly legendItems = (['elNino', 'laNina'] as const).map((phase) => ({
-    label: phase === 'elNino' ? 'El Niño' : 'La Niña',
-    path: getShapePath(PHASE_STYLE[phase].shape, PHASE_STYLE[phase].size),
-    color: PHASE_STYLE[phase].fill,
-    stroke: PHASE_STYLE[phase].stroke,
+  public override getLegendItems(): ILegendItem[] {
+    return [
+      { ...STYLES.elNino, label: 'El Niño', strokeWidth: 1.5 },
+      { ...STYLES.laNina, label: 'La Niña', strokeWidth: 1.5 },
+    ];
+  }
+
+  public readonly legendItems = (this.getLegendItems() || []).map((item) => ({
+    label: item.label,
+    path: getShapePath(item.shape, 10),
+    color: item.fill,
+    stroke: item.stroke,
   }));
 
   public override getPointStyle(d: DataPoint): IPointStyle | undefined {
     if (!this.isDecoratable(d)) return undefined;
-    return PHASE_STYLE[phaseOf(d.x)];
+    return STYLES[phaseOf(d.x)];
   }
 
   public override formatTooltipRow(year: number): ITooltipExtraRow | undefined {
     if (!this.validXValues().has(year)) return undefined;
     const phase = phaseOf(year);
-    if (phase === 'elNino') return { text: `▲ El Niño`, color: '#d4802b' };
-    if (phase === 'laNina') return { text: `■ La Niña`, color: '#13599e' };
+    if (phase === 'elNino') return { text: `▲ El Niño`, color: STYLES.elNino.fill };
+    if (phase === 'laNina') return { text: `■ La Niña`, color: STYLES.laNina.fill };
     return undefined;
   }
 }

--- a/apps/picsa-tools/climate-tool/src/app/services/climate-chart.service.ts
+++ b/apps/picsa-tools/climate-tool/src/app/services/climate-chart.service.ts
@@ -15,7 +15,13 @@ import { firstValueFrom, Subject } from 'rxjs';
 
 import { BaseChartToolComponent, TOOL_SERIES_IDS } from '../components/chart-tools/base-tool.component';
 import { generateChartConfig } from '../utils';
-import { clearPointOverlay, IOverlayPoint, renderPointOverlay } from '../utils/chart-point-overlay';
+import {
+  clearPointOverlay,
+  clearSvgLegend,
+  IOverlayPoint,
+  renderPointOverlay,
+  renderSvgLegend,
+} from '../utils/chart-point-overlay';
 import { ClimateDataService } from './climate-data.service';
 import { ClimateToolService } from './climate-tool.service';
 
@@ -87,6 +93,7 @@ export class ClimateChartService {
         this.syncPointOverlay();
       } else {
         clearPointOverlay(this.chartComponent?.chart);
+        clearSvgLegend(this.chartComponent?.chart);
       }
     });
   }
@@ -218,6 +225,9 @@ export class ClimateChartService {
       };
       config.point!.r = (d) => {
         if (TOOL_SERIES_IDS.includes(d.id)) return 0;
+        if (d.value === null || d.value === undefined || typeof d.value !== 'number' || !Number.isFinite(d.value)) {
+          return 0;
+        }
         return this.getPointRadius(d as DataPoint) ?? this.pointRadius();
       };
       config.tooltip = config.tooltip || {};
@@ -256,24 +266,35 @@ export class ClimateChartService {
     const definition = this.chartDefinition();
     if (!tool?.usesPointOverlay || !definition) {
       clearPointOverlay(chart);
+      clearSvgLegend(chart);
       return;
     }
 
     const xVar = definition.xVar || 'Year';
     const points: IOverlayPoint[] = [];
+    const isValidVal = (val: any): boolean => typeof val === 'number' && Number.isFinite(val);
 
     for (const row of this.stationData()) {
       const x = row[xVar] as number;
-      if (!Number.isFinite(x)) continue;
+      if (!isValidVal(x)) continue;
       for (const key of definition.keys) {
         const value = row[key] as number;
-        if (!Number.isFinite(value)) continue;
+        if (!isValidVal(value)) continue;
         const style = tool.getPointStyle({ id: key, x, value, index: -1 } as DataPoint);
         if (style) points.push({ id: key, x, value, style });
       }
     }
 
-    renderPointOverlay(chart, points, this.pointRadius() / ClimateChartService.DEFAULT_POINT_RADIUS);
+    const scale = Math.max(0.6, this.pointRadius() / ClimateChartService.DEFAULT_POINT_RADIUS);
+    renderPointOverlay(chart, points, scale);
+
+    const legendItems = tool.getLegendItems();
+    // Render SVG legend on canvas ONLY in print version (so it is captured in PNG export without appearing on normal screen)
+    if (this.isPrintVersion && legendItems?.length) {
+      renderSvgLegend(chart, legendItems, scale);
+    } else {
+      clearSvgLegend(chart);
+    }
   }
 
   /*****************************************************************************
@@ -365,15 +386,19 @@ export class ClimateChartService {
 
     // if cache config exists revert back
     if (this.isPrintVersion) {
-      this.chartConfig.set({ ...config, size: { width: 900, height: 500 }, title: { text: '' } });
+      this.chartConfig.set({
+        ...config,
+        size: { width: 900, height: 530 },
+        padding: { bottom: 40, right: 10, left: 60 },
+        title: { text: '' },
+      });
       this.pointRadius.set(3);
     } else {
-      const newConfig = { ...config, size: undefined };
+      const newConfig = { ...config, size: undefined, padding: undefined };
       this.chartConfig.set(newConfig);
       this.pointRadius.set(ClimateChartService.DEFAULT_POINT_RADIUS);
     }
 
-    window.dispatchEvent(new CustomEvent('picsaChartRerender'));
     // Ensure graphics updated by waiting for chart render notification and timeout
     await firstValueFrom(this.chartRendered$);
     await _wait(500);

--- a/apps/picsa-tools/climate-tool/src/app/services/climate-chart.service.ts
+++ b/apps/picsa-tools/climate-tool/src/app/services/climate-chart.service.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { computed, effect, inject, Injectable, signal, untracked } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { MONTH_DATA } from '@picsa/data';
 import { PicsaTranslateService } from '@picsa/i18n';
@@ -12,8 +13,9 @@ import { DataPoint } from 'c3';
 import { getDayOfYear } from 'date-fns';
 import { firstValueFrom, Subject } from 'rxjs';
 
-import type { BaseChartToolComponent } from '../components/chart-tools/base-tool.component';
+import { BaseChartToolComponent, TOOL_SERIES_IDS } from '../components/chart-tools/base-tool.component';
 import { generateChartConfig } from '../utils';
+import { clearPointOverlay, IOverlayPoint, renderPointOverlay } from '../utils/chart-point-overlay';
 import { ClimateDataService } from './climate-data.service';
 import { ClimateToolService } from './climate-tool.service';
 
@@ -52,7 +54,8 @@ export class ClimateChartService {
 
   /** Track whether print mode has been toggled */
   private isPrintVersion = false;
-  private pointRadius = 8;
+  private static readonly DEFAULT_POINT_RADIUS = 8;
+  private readonly pointRadius = signal(ClimateChartService.DEFAULT_POINT_RADIUS);
 
   private monthNames: string[] = [];
 
@@ -72,6 +75,20 @@ export class ClimateChartService {
         this.dataService.setPreferredStation(station.id);
       }
     });
+
+    // Re-render custom marker overlay after every chart render (covers resize,
+    // data load/unload, config change and print toggling)
+    this.chartRendered$.pipe(takeUntilDestroyed()).subscribe(() => this.syncPointOverlay());
+
+    // Synchronize overlay whenever active tool changes (instant rendering on tool toggle without chart re-render)
+    effect(() => {
+      const tool = this.activeToolHandler();
+      if (tool?.usesPointOverlay) {
+        this.syncPointOverlay();
+      } else {
+        clearPointOverlay(this.chartComponent?.chart);
+      }
+    });
   }
 
   /**
@@ -83,7 +100,7 @@ export class ClimateChartService {
     this.chartConfig.set(undefined);
     this.chartDefinition.set(undefined);
     this.setStation(undefined);
-    this.getPointColour = () => undefined;
+    this.activeToolHandler.set(undefined);
   }
 
   /**
@@ -195,10 +212,13 @@ export class ClimateChartService {
       };
 
       // override point color, radius and tooltip if function set
-      config.data!.color = (color, d) => this.getPointColour(d as DataPoint) || color;
+      config.data!.color = (color, d) => {
+        if (TOOL_SERIES_IDS.includes((d as DataPoint).id)) return color;
+        return this.getPointColour(d as DataPoint) || color;
+      };
       config.point!.r = (d) => {
-        if (['LineTool', 'upperTercile', 'lowerTercile'].includes(d.id)) return 0;
-        return this.getPointRadius(d as DataPoint) ?? this.pointRadius;
+        if (TOOL_SERIES_IDS.includes(d.id)) return 0;
+        return this.getPointRadius(d as DataPoint) ?? this.pointRadius();
       };
       config.tooltip = config.tooltip || {};
       config.tooltip.contents = (d: any, defaultTitleFormat: any, defaultValueFormat: any, color: any) => {
@@ -222,6 +242,38 @@ export class ClimateChartService {
     } else {
       console.warn('No chart found', id, station);
     }
+  }
+
+  /**
+   * Build the marker list from station data and hand it to the overlay renderer.
+   * Markers are applied to every series key on the active chart.
+   */
+  private syncPointOverlay() {
+    const chart = this.chartComponent?.chart;
+    if (!chart) return;
+
+    const tool = this.activeToolHandler();
+    const definition = this.chartDefinition();
+    if (!tool?.usesPointOverlay || !definition) {
+      clearPointOverlay(chart);
+      return;
+    }
+
+    const xVar = definition.xVar || 'Year';
+    const points: IOverlayPoint[] = [];
+
+    for (const row of this.stationData()) {
+      const x = row[xVar] as number;
+      if (!Number.isFinite(x)) continue;
+      for (const key of definition.keys) {
+        const value = row[key] as number;
+        if (!Number.isFinite(value)) continue;
+        const style = tool.getPointStyle({ id: key, x, value, index: -1 } as DataPoint);
+        if (style) points.push({ id: key, x, value, style });
+      }
+    }
+
+    renderPointOverlay(chart, points, this.pointRadius() / ClimateChartService.DEFAULT_POINT_RADIUS);
   }
 
   /*****************************************************************************
@@ -286,7 +338,7 @@ export class ClimateChartService {
 
     // Generate a png representation of currently rendered chart so that it
     // can be embedded in custom print-layout component
-    const svgElement = document.querySelector<SVGSVGElement>('#picsa_chart_svg');
+    const svgElement = (this.chartComponent?.chart as any)?.internal?.svg?.node() as SVGSVGElement | undefined;
     if (svgElement) {
       const pngBlob = await this.printProvider.svgToPngBlob(svgElement);
       if (pngBlob) {
@@ -314,11 +366,11 @@ export class ClimateChartService {
     // if cache config exists revert back
     if (this.isPrintVersion) {
       this.chartConfig.set({ ...config, size: { width: 900, height: 500 }, title: { text: '' } });
-      this.pointRadius = 3;
+      this.pointRadius.set(3);
     } else {
       const newConfig = { ...config, size: undefined };
       this.chartConfig.set(newConfig);
-      this.pointRadius = 8;
+      this.pointRadius.set(ClimateChartService.DEFAULT_POINT_RADIUS);
     }
 
     window.dispatchEvent(new CustomEvent('picsaChartRerender'));

--- a/apps/picsa-tools/climate-tool/src/app/services/climate-chart.service.ts
+++ b/apps/picsa-tools/climate-tool/src/app/services/climate-chart.service.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { computed, effect, inject, Injectable, signal, untracked } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { MONTH_DATA } from '@picsa/data';
 import { PicsaTranslateService } from '@picsa/i18n';
@@ -55,8 +54,9 @@ export class ClimateChartService {
   private _chartRendered = new Subject<void>();
   chartRendered$ = this._chartRendered.asObservable();
 
-  /** Binding for active rendered chart component */
-  public chartComponent?: PicsaChartComponent;
+  /** Binding for active rendered chart component and active C3 chart API */
+  readonly chartComponent = signal<PicsaChartComponent | undefined>(undefined);
+  readonly chart = computed(() => this.chartComponent()?.chart());
 
   /** Track whether print mode has been toggled */
   private isPrintVersion = false;
@@ -82,18 +82,15 @@ export class ClimateChartService {
       }
     });
 
-    // Re-render custom marker overlay after every chart render (covers resize,
-    // data load/unload, config change and print toggling)
-    this.chartRendered$.pipe(takeUntilDestroyed()).subscribe(() => this.syncPointOverlay());
-
-    // Synchronize overlay whenever active tool changes (instant rendering on tool toggle without chart re-render)
+    // Synchronize overlay whenever chart instance or active tool changes
     effect(() => {
+      const chart = this.chart();
       const tool = this.activeToolHandler();
-      if (tool?.usesPointOverlay) {
+      if (chart && tool?.usesPointOverlay) {
         this.syncPointOverlay();
-      } else {
-        clearPointOverlay(this.chartComponent?.chart);
-        clearSvgLegend(this.chartComponent?.chart);
+      } else if (chart) {
+        clearPointOverlay(chart);
+        clearSvgLegend(chart);
       }
     });
   }
@@ -114,7 +111,7 @@ export class ClimateChartService {
    * Provide access to the current chart for use in tools.
    */
   public registerChartComponent(chart: PicsaChartComponent) {
-    this.chartComponent = chart;
+    this.chartComponent.set(chart);
   }
 
   /**
@@ -232,7 +229,7 @@ export class ClimateChartService {
       };
       config.tooltip = config.tooltip || {};
       config.tooltip.contents = (d: any, defaultTitleFormat: any, defaultValueFormat: any, color: any) => {
-        const chartApi = this.chartComponent?.chart as any;
+        const chartApi = this.chart();
         let html = chartApi?.internal?.getTooltipContent(d, defaultTitleFormat, defaultValueFormat, color) || '';
         const year = d[0]?.x;
         if (typeof year === 'number' && this.formatTooltipRow) {
@@ -259,7 +256,7 @@ export class ClimateChartService {
    * Markers are applied to every series key on the active chart.
    */
   private syncPointOverlay() {
-    const chart = this.chartComponent?.chart;
+    const chart = this.chart();
     if (!chart) return;
 
     const tool = this.activeToolHandler();
@@ -306,7 +303,7 @@ export class ClimateChartService {
    * NOTE - to remove the points the chart config also needs to be included in hardcoded config
    */
   public addFixedLineToChart(value: number, id: string) {
-    const chart = this.chartComponent?.chart;
+    const chart = this.chart();
     if (!chart) return;
     if (value) {
       const dataLength = this.stationData().length;
@@ -325,7 +322,7 @@ export class ClimateChartService {
   }
 
   public removeSeriesFromChart(ids: string[]) {
-    const chart = this.chartComponent?.chart;
+    const chart = this.chart();
     if (!chart) return;
     try {
       chart.hide(ids);
@@ -359,7 +356,7 @@ export class ClimateChartService {
 
     // Generate a png representation of currently rendered chart so that it
     // can be embedded in custom print-layout component
-    const svgElement = (this.chartComponent?.chart as any)?.internal?.svg?.node() as SVGSVGElement | undefined;
+    const svgElement = this.chart()?.internal?.svg?.node() as SVGSVGElement | undefined;
     if (svgElement) {
       const pngBlob = await this.printProvider.svgToPngBlob(svgElement);
       if (pngBlob) {

--- a/apps/picsa-tools/climate-tool/src/app/services/climate-chart.service.ts
+++ b/apps/picsa-tools/climate-tool/src/app/services/climate-chart.service.ts
@@ -389,7 +389,7 @@ export class ClimateChartService {
       this.chartConfig.set({
         ...config,
         size: { width: 900, height: 530 },
-        padding: { bottom: 40, right: 10, left: 60 },
+        padding: { bottom: 45, right: 10, left: 60 },
         title: { text: '' },
       });
       this.pointRadius.set(3);

--- a/apps/picsa-tools/climate-tool/src/app/utils/chart-point-overlay.ts
+++ b/apps/picsa-tools/climate-tool/src/app/utils/chart-point-overlay.ts
@@ -1,0 +1,76 @@
+import type { ChartAPI } from 'c3';
+import { select } from 'd3-selection';
+
+import type { IPointStyle, PointShape } from '../components/chart-tools/base-tool.component';
+
+const LAYER_CLASS = 'picsa-point-overlay';
+const OVERLAY_ACTIVE_CLASS = 'picsa-overlay-active';
+
+const SHAPE_PATH: Record<PointShape, (s: number) => string> = {
+  circle: (s) => `M ${-s},0 a ${s},${s} 0 1,0 ${2 * s},0 a ${s},${s} 0 1,0 ${-2 * s},0`,
+  square: (s) => `M ${-s},${-s} h ${2 * s} v ${2 * s} h ${-2 * s} Z`,
+  triangle: (s) => `M 0,${-s} L ${s * 0.866},${s * 0.5} L ${-s * 0.866},${s * 0.5} Z`,
+  diamond: (s) => `M 0,${-s} L ${s},0 L 0,${s} L ${-s},0 Z`,
+};
+
+export interface IOverlayPoint {
+  /** series key, used to resolve the correct y axis (y or y2) */
+  id: string;
+  x: number;
+  value: number;
+  style: IPointStyle;
+}
+
+/** Path string for a shape, exposed so legends can share marker geometry */
+export function getShapePath(shape: PointShape, size: number): string {
+  return SHAPE_PATH[shape](size);
+}
+
+/**
+ * Render custom point markers into a dedicated layer inside the chart's main group.
+ *
+ * Uses a keyed data join so repeat calls are idempotent and cheap - safe to run on
+ * every `onrendered`. The layer is pointer-events:none so C3's own (hidden) circles
+ * retain tooltip hit targets.
+ *
+ * Paint properties are set as inline CSS styles so they override C3's `.c3 path` default rules
+ * and are captured correctly by SVG->PNG export.
+ */
+export function renderPointOverlay(chart: ChartAPI, points: IOverlayPoint[], scale = 1) {
+  const internal = (chart as any)?.internal;
+  if (!internal?.main) return;
+
+  const mainNode = internal.main.node() as SVGGElement;
+  mainNode.classList.add(OVERLAY_ACTIVE_CLASS);
+
+  const root = select<SVGGElement, unknown>(mainNode);
+  let layer = root.select<SVGGElement>(`g.${LAYER_CLASS}`);
+  if (layer.empty()) {
+    layer = root.append('g').attr('class', LAYER_CLASS).attr('pointer-events', 'none');
+  }
+
+  layer
+    .selectAll<SVGPathElement, IOverlayPoint>('path')
+    .data(points, (d) => `${d.id}:${d.x}`)
+    .join('path')
+    .attr('d', (d) => getShapePath(d.style.shape, d.style.size * scale))
+    .attr('transform', (d) => `translate(${internal.x(d.x)},${internal.getYScale(d.id)(d.value)})`)
+    .style('fill', (d) => d.style.fill)
+    .style('stroke', (d) => d.style.stroke ?? 'none')
+    .style('stroke-width', (d) => `${(d.style.strokeWidth ?? 0) * scale}px`)
+    .style('opacity', (d) => (d.style.opacity ?? 1).toString())
+    .attr('fill', (d) => d.style.fill)
+    .attr('stroke', (d) => d.style.stroke ?? 'none')
+    .attr('stroke-width', (d) => (d.style.strokeWidth ?? 0) * scale)
+    .attr('opacity', (d) => d.style.opacity ?? 1);
+}
+
+export function clearPointOverlay(chart?: ChartAPI) {
+  const internal = (chart as any)?.internal;
+  if (!internal?.main) return;
+
+  const mainNode = internal.main.node() as SVGGElement;
+  mainNode.classList.remove(OVERLAY_ACTIVE_CLASS);
+
+  select(mainNode).select(`g.${LAYER_CLASS}`).remove();
+}

--- a/apps/picsa-tools/climate-tool/src/app/utils/chart-point-overlay.ts
+++ b/apps/picsa-tools/climate-tool/src/app/utils/chart-point-overlay.ts
@@ -1,9 +1,10 @@
 import type { ChartAPI } from 'c3';
 import { select } from 'd3-selection';
 
-import type { IPointStyle, PointShape } from '../components/chart-tools/base-tool.component';
+import type { ILegendItem, IPointStyle, PointShape } from '../components/chart-tools/base-tool.component';
 
 const LAYER_CLASS = 'picsa-point-overlay';
+const LEGEND_LAYER_CLASS = 'picsa-legend-overlay';
 const OVERLAY_ACTIVE_CLASS = 'picsa-overlay-active';
 
 const SHAPE_PATH: Record<PointShape, (s: number) => string> = {
@@ -43,6 +44,9 @@ export function renderPointOverlay(chart: ChartAPI, points: IOverlayPoint[], sca
   const mainNode = internal.main.node() as SVGGElement;
   mainNode.classList.add(OVERLAY_ACTIVE_CLASS);
 
+  // Directly set inline opacity: 0 on standard C3 circles so computedStyle in serializeSvgWithStyles sees 0
+  select(mainNode).selectAll('.c3-circles .c3-circle').style('opacity', '0');
+
   const root = select<SVGGElement, unknown>(mainNode);
   let layer = root.select<SVGGElement>(`g.${LAYER_CLASS}`);
   if (layer.empty()) {
@@ -65,6 +69,90 @@ export function renderPointOverlay(chart: ChartAPI, points: IOverlayPoint[], sca
     .attr('opacity', (d) => d.style.opacity ?? 1);
 }
 
+interface ISvgLegendItem extends ILegendItem {
+  x: number;
+  y: number;
+}
+
+/**
+ * Render a declarative tool legend directly onto the SVG canvas.
+ * Renders below the plot area so it is captured directly by SVG->PNG export without requiring HTML elements.
+ */
+export function renderSvgLegend(chart: ChartAPI, legendItems: ILegendItem[], scale = 1) {
+  const internal = (chart as any)?.internal;
+  if (!internal?.svg || !legendItems?.length) return;
+
+  const svgNode = internal.svg.node() as SVGSVGElement;
+  const root = select<SVGSVGElement, unknown>(svgNode);
+
+  let legendLayer = root.select<SVGGElement>(`g.${LEGEND_LAYER_CLASS}`);
+  if (legendLayer.empty()) {
+    legendLayer = root.append('g').attr('class', LEGEND_LAYER_CLASS);
+  }
+
+  const chartWidth = internal.currentWidth || 900;
+  const chartHeight = internal.currentHeight || 530;
+
+  const itemGap = 48;
+  const iconTextGap = 12;
+  const approxItemWidth = 90;
+  const totalWidth = legendItems.length * approxItemWidth + (legendItems.length - 1) * itemGap;
+  let currentX = Math.max(40, (chartWidth - totalWidth) / 2);
+  const legendY = chartHeight - 24;
+
+  const data: ISvgLegendItem[] = legendItems.map((item) => {
+    const x = currentX;
+    currentX += approxItemWidth + itemGap;
+    return { ...item, x, y: legendY };
+  });
+
+  const items = legendLayer
+    .selectAll<SVGGElement, ISvgLegendItem>('g.legend-item')
+    .data(data, (d) => d.label)
+    .join((enter) => {
+      const g = enter.append('g').attr('class', 'legend-item');
+      g.append('path');
+      g.append('text');
+      return g;
+    });
+
+  items.attr('transform', (d) => `translate(${d.x},${d.y})`);
+
+  items
+    .select('path')
+    .attr('d', (d) => getShapePath(d.shape, 6))
+    .style('fill', (d) => d.fill)
+    .style('stroke', (d) => d.stroke ?? 'none')
+    .style('stroke-width', (d) => `${d.strokeWidth ?? 1}px`)
+    .style('opacity', '1')
+    .attr('fill', (d) => d.fill)
+    .attr('stroke', (d) => d.stroke ?? 'none')
+    .attr('stroke-width', (d) => d.strokeWidth ?? 1)
+    .attr('opacity', '1');
+
+  items
+    .select('text')
+    .attr('x', iconTextGap)
+    .attr('y', 0)
+    .style('dominant-baseline', 'central')
+    .style('fill', '#222222')
+    .style('font-size', '13px')
+    .style('font-family', 'sans-serif')
+    .style('font-weight', '600')
+    .attr('dominant-baseline', 'central')
+    .attr('fill', '#222222')
+    .attr('font-size', '13px')
+    .attr('font-family', 'sans-serif')
+    .attr('font-weight', '600')
+    .text((d) => d.label);
+}
+
+export function clearSvgLegend(chart?: ChartAPI) {
+  const internal = (chart as any)?.internal;
+  if (!internal?.svg) return;
+  select(internal.svg.node()).select(`g.${LEGEND_LAYER_CLASS}`).remove();
+}
+
 export function clearPointOverlay(chart?: ChartAPI) {
   const internal = (chart as any)?.internal;
   if (!internal?.main) return;
@@ -72,5 +160,8 @@ export function clearPointOverlay(chart?: ChartAPI) {
   const mainNode = internal.main.node() as SVGGElement;
   mainNode.classList.remove(OVERLAY_ACTIVE_CLASS);
 
-  select(mainNode).select(`g.${LAYER_CLASS}`).remove();
+  const root = select(mainNode);
+  root.select(`g.${LAYER_CLASS}`).remove();
+  clearSvgLegend(chart);
+  root.selectAll('.c3-circles .c3-circle').style('opacity', null);
 }

--- a/libs/shared/src/features/charts/chart.scss
+++ b/libs/shared/src/features/charts/chart.scss
@@ -60,3 +60,26 @@ picsa-chart {
   font-size: 20px;
   font-weight: bold;
 }
+
+// When using custom marker overlay hide default styled points
+.picsa-overlay-active .c3-circles .c3-circle {
+  opacity: 0 !important;
+}
+
+.picsa-point-overlay {
+  animation: picsa-overlay-fade 200ms ease-out;
+
+  path {
+    fill: inherit;
+    stroke: inherit;
+  }
+}
+
+@keyframes picsa-overlay-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/libs/shared/src/features/charts/chart.ts
+++ b/libs/shared/src/features/charts/chart.ts
@@ -61,6 +61,10 @@ export class PicsaChartComponent {
 
   // use create method to populate div which will also be available before viewInit
   private create(config: Partial<c3.ChartConfiguration>) {
+    const userOnrendered = config.onrendered;
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const component = this;
+
     this.chart = c3.generate({
       ...config,
       bindto: this.chartContainer.nativeElement,
@@ -68,14 +72,22 @@ export class PicsaChartComponent {
       size: config.size || {
         height: this.elementRef.nativeElement.offsetHeight - 32, // include extra pxs for labels
       },
-      oninit: function () {
+      oninit() {
         this.svg.attr('id', 'picsa_chart_svg');
       },
+      /**
+       * Ensure `component.chart` is assigned to the new chart API before `userOnrendered` executes.
+       * `c3.generate()` fires `onrendered` synchronously before returning its instance, which would
+       * otherwise cause subscribers (e.g. print export & tool overlays) to reference a stale or undefined chart.
+       */
+      onrendered() {
+        const api = this?.api;
+        if (api) {
+          component.chart = api;
+        }
+        userOnrendered?.call(this);
+      },
     });
-    // Ensure onrendered runs with this.chart fully assigned
-    if (this.chart && config.onrendered) {
-      config.onrendered.call((this.chart as any)?.internal);
-    }
   }
 }
 

--- a/libs/shared/src/features/charts/chart.ts
+++ b/libs/shared/src/features/charts/chart.ts
@@ -72,6 +72,10 @@ export class PicsaChartComponent {
         this.svg.attr('id', 'picsa_chart_svg');
       },
     });
+    // Ensure onrendered runs with this.chart fully assigned
+    if (this.chart && config.onrendered) {
+      config.onrendered.call((this.chart as any)?.internal);
+    }
   }
 }
 

--- a/libs/shared/src/features/charts/chart.ts
+++ b/libs/shared/src/features/charts/chart.ts
@@ -1,10 +1,13 @@
 import {
   Component,
+  DestroyRef,
   effect,
   ElementRef,
   HostListener,
   inject,
   input,
+  signal,
+  untracked,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
@@ -27,45 +30,43 @@ import * as c3 from 'c3';
 export class PicsaChartComponent {
   private elementRef = inject<ElementRef<HTMLDivElement>>(ElementRef);
 
-  public chart: c3.ChartAPI;
-
   @ViewChild('chart', { static: true })
   chartContainer: ElementRef<HTMLDivElement>;
 
-  config = input.required<IChartConfig>();
+  readonly config = input.required<IChartConfig>();
+  readonly chart = signal<c3.ChartAPI | undefined>(undefined);
 
-  // dispatch resize event to trigger chart resize on orientation change
-  @HostListener('window:orientationchange', [])
-  onOrientationChange() {
-    if (this.chart) {
-      setTimeout(() => {
-        this.create(this.config());
-      }, 200);
-    }
-  }
-  /** Custom event to force rerender (e.g. deep config changes not picked uo) */
-  @HostListener('window:picsaChartRerender', [])
-  chartRerender() {
-    if (this.chart) {
-      setTimeout(() => {
-        this.create(this.config());
-      }, 200);
-    }
-  }
   constructor() {
     effect(() => {
       const config = this.config();
-      this.create(config);
+      untracked(() => this.create(config));
     });
+
+    inject(DestroyRef).onDestroy(() => this.destroy());
+  }
+
+  @HostListener('window:orientationchange', [])
+  @HostListener('window:picsaChartRerender', [])
+  rerender() {
+    if (this.chart()) {
+      setTimeout(() => this.create(this.config()), 200);
+    }
+  }
+
+  private destroy() {
+    try {
+      this.chart()?.destroy();
+    } catch {
+      /* empty */
+    }
+    this.chart.set(undefined);
   }
 
   // use create method to populate div which will also be available before viewInit
   private create(config: Partial<c3.ChartConfiguration>) {
-    const userOnrendered = config.onrendered;
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const component = this;
+    this.destroy();
 
-    this.chart = c3.generate({
+    const chart = c3.generate({
       ...config,
       bindto: this.chartContainer.nativeElement,
       data: config.data || {},
@@ -75,19 +76,9 @@ export class PicsaChartComponent {
       oninit() {
         this.svg.attr('id', 'picsa_chart_svg');
       },
-      /**
-       * Ensure `component.chart` is assigned to the new chart API before `userOnrendered` executes.
-       * `c3.generate()` fires `onrendered` synchronously before returning its instance, which would
-       * otherwise cause subscribers (e.g. print export & tool overlays) to reference a stale or undefined chart.
-       */
-      onrendered() {
-        const api = this?.api;
-        if (api) {
-          component.chart = api;
-        }
-        userOnrendered?.call(this);
-      },
     });
+
+    this.chart.set(chart);
   }
 }
 

--- a/libs/shared/src/services/native/print.ts
+++ b/libs/shared/src/services/native/print.ts
@@ -1,4 +1,4 @@
-import { inject,Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { SocialSharing } from '@awesome-cordova-plugins/social-sharing/ngx';
 import { Capacitor } from '@capacitor/core';
 import { _wait } from '@picsa/utils';
@@ -50,21 +50,24 @@ export class PrintProvider {
    */
   public async svgToPngBlob(
     svgElement: SVGSVGElement,
-    options = { width: 900, height: 500, scale: 1, backgroundColor: 'white' },
+    options?: { width?: number; height?: number; scale?: number; backgroundColor?: string },
   ): Promise<Blob> {
-    const { width, height, scale = 1, backgroundColor = 'transparent' } = options;
+    const svgRect = svgElement.getBoundingClientRect();
+    const width = options?.width || (svgRect.width > 0 ? svgRect.width : 900);
+    const height = options?.height || (svgRect.height > 0 ? svgRect.height : 530);
+    const scale = options?.scale || 1;
+    const backgroundColor = options?.backgroundColor || 'white';
 
     // Get computed styles and serialize the SVG
-    const serializedSvg = serializeSvgWithStyles(svgElement);
+    const serializedSvg = serializeSvgWithStyles(svgElement, width, height);
 
     // Create canvas
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
 
     // Set canvas dimensions
-    const svgRect = svgElement.getBoundingClientRect();
-    canvas.width = (width || svgRect.width) * scale;
-    canvas.height = (height || svgRect.height) * scale;
+    canvas.width = width * scale;
+    canvas.height = height * scale;
 
     // Scale context if needed
     if (scale !== 1) {
@@ -111,23 +114,68 @@ export class PrintProvider {
   }
 }
 
+const SVG_STYLE_PROPERTIES = [
+  'fill',
+  'fill-opacity',
+  'stroke',
+  'stroke-width',
+  'stroke-linecap',
+  'stroke-linejoin',
+  'stroke-dasharray',
+  'stroke-opacity',
+  'opacity',
+  'font-family',
+  'font-size',
+  'font-weight',
+  'font-style',
+  'text-anchor',
+  'dominant-baseline',
+  'display',
+  'visibility',
+  'shape-rendering',
+  'clip-path',
+];
+
 /** Take an svgElement and inline any inherited styles */
-function serializeSvgWithStyles(svgElement: SVGElement) {
+function serializeSvgWithStyles(svgElement: SVGElement, width = 900, height = 530) {
   // Clone the SVG to avoid modifying the original
   const clonedSvg = svgElement.cloneNode(true) as SVGElement;
+
+  clonedSvg.setAttribute('width', width.toString());
+  clonedSvg.setAttribute('height', height.toString());
+  if (!clonedSvg.getAttribute('viewBox')) {
+    clonedSvg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+  }
 
   // Get all elements in the SVG
   const allElements = [clonedSvg, ...clonedSvg.querySelectorAll('*')];
 
-  // Apply computed styles to each element
+  // Apply computed styles to each element for relevant SVG presentation properties only
   allElements.forEach((element, index) => {
     const originalElement = index === 0 ? svgElement : svgElement.querySelectorAll('*')[index - 1];
 
     if (originalElement) {
+      // If the element is part of custom point overlay or legend overlay, preserve its explicit attributes and styles
+      const isCustomOverlay = originalElement.closest('.picsa-point-overlay, .picsa-legend-overlay');
+      if (isCustomOverlay) {
+        return;
+      }
+
+      // If chart overlay is active and element is a standard c3 circle, force opacity 0 and display none
+      if (originalElement.classList.contains('c3-circle')) {
+        const isOverlayActive = svgElement.querySelector('.picsa-point-overlay') !== null;
+        if (isOverlayActive) {
+          element.setAttribute('style', 'opacity: 0 !important; display: none !important;');
+          return;
+        }
+      }
+
       const computedStyle = window.getComputedStyle(originalElement);
-      const styleString = Array.from(computedStyle)
-        .filter((prop) => computedStyle.getPropertyValue(prop))
-        .map((prop) => `${prop}: ${computedStyle.getPropertyValue(prop)}`)
+      const styleString = SVG_STYLE_PROPERTIES.map((prop) => {
+        const val = computedStyle.getPropertyValue(prop);
+        return val ? `${prop}: ${val}` : '';
+      })
+        .filter(Boolean)
         .join('; ');
 
       if (styleString) {


### PR DESCRIPTION
## Developer Summary

> Info for reviewer, e.g. use of ai, pain points/challenges, discussion points for monthly dev call

## Related Issues

> Link any related issues (e.g., `Closes #[issue_number]`, `Relates to #[issue_number]`)

## Screenshots / Videos

**Example** - generated png output for sharing. El nino symbols preserved and legend added
<img width="2100" height="1500" alt="CHIPEPO MET - Seasonal Rainfall (19)" src="https://github.com/user-attachments/assets/8a32c3a8-25c9-406f-9063-adac069ec562" />

---

## AI Summary

> Will be generated on PR open. Regenerate by typing comment `/describe` in PR
> More info at https://docs.pr-agent.ai/tools/describe/

### Description

### 🤖 Generated by PR Agent at 4bbca089796291b0c23ef4cbc0339e9eadf50f89

- Replace manual DOM shape patching with declarative marker overlay
- Centralise point/legend rendering in new `chart-point-overlay` utility
- Fix El Niño overlay not appearing in PNG print export
- Hoist shared `validXValues`/`isDecoratable` into base chart tool


### Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>base-tool.component.ts</strong><dd><code>Add declarative point/legend interfaces to base</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/677/files#diff-e793090f272aeff25f4af6d9876af7522ada126c447b0ec63eff9688199d1352">+68/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>el-nino-tool.component.ts</strong><dd><code>Refactor El Niño tool to use point overlay</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/677/files#diff-c0bed4382a58047f142ebb6c112042328d2180a0a2e43cfcc54630f1d60ac5a6">+38/-275</a></td>

</tr>

<tr>
  <td><strong>climate-chart.service.ts</strong><dd><code>Sync marker overlay via chart service effects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/677/files#diff-8a9442e8f7b117fb4e0d9735a31b834284dc3931f13a470afbad1f5c747ccaab">+89/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>chart-point-overlay.ts</strong><dd><code>New d3-driven point overlay and SVG legend renderer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/677/files#diff-e24b47b954a325046e80c89a735ff6e857aada8a60a63fc53e35736fd243b9c1">+167/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>chart.scss</strong><dd><code>Hide default c3 circles when overlay active</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/677/files#diff-3a80479d83b9de59ae2e23b8c4e4f20b13048c4fe6e86381d613dc6cbcdff2b6">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>chart.ts</strong><dd><code>Trigger onrendered after chart assignment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/677/files#diff-586e0ca9bd2b75049c3de76bff65c6db870250b1819a05747f7b51e6a809ebc7">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>print.ts</strong><dd><code>Preserve overlay styles in SVG-to-PNG export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/677/files#diff-1636adf58191967b89158e89316bc6479b52897d85a7baf76f3d27c638f9fcc4">+60/-12</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactor</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>el-nino-tool.component.html</strong><dd><code>Render legend via SVG markers in template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/677/files#diff-c27e05cbb1af891d54c5eeaac6b50f233e143bbebf9738a479a4a994a098d371">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>el-nino-tool.component.scss</strong><dd><code>Update legend styles to match overlay markers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/677/files#diff-9aa56b1d79a210cccbbec733f7b3751e5107dd1cd1ef9a81ae1eb4d127db8b1e">+14/-15</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

### Diagram


```mermaid
  flowchart LR
    Tool["ElNinoTool<br/>usesPointOverlay=true"] -->|"getPointStyle()<br/>getLegendItems()"| Overlay["chart-point-overlay.ts"]
    Overlay -->|"renderPointOverlay"| SVG["Chart SVG<br/>picsa-point-overlay layer"]
    Overlay -->|"renderSvgLegend<br/>(print only)"| SVG
    Service["ClimateChartService<br/>syncPointOverlay"] --> Overlay
    Print["printChartAsPng()"] --> Service
    Print -->|"togglePrintVersion"| Service
    Print -->|"svgToPngBlob"| Export["Inlined SVG styles<br/>preserving overlay"]
    Service -->|"chartRendered$"| Sync["Rx effect<br/>re-render overlay"]
    Service -->|"activeToolHandler()"| Sync
```