### PR TITLE
[FEATURE] Forecasts manual refresh

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -30,6 +30,7 @@
   { 'color': '000000', 'description': 'Updates related to Option tool', 'name': 'Tool: Option' },
   { 'color': '000000', 'description': 'Updates related to Resources tool', 'name': 'Tool: Resources' },
   { 'color': '000000', 'description': 'Updates related to Seasonal Calendar tool', 'name': 'Tool: Seasonal Calendar' },
+  { 'color': '000000', 'description': 'Updates related to Forecast tool', 'name': 'Tools: Forecasts' },
   # PICSA Apps
   { 'color': '000000', 'description': 'Updates related to Dashboard app', 'name': 'App: Dashboard' },
   { 'color': '000000', 'description': 'Updates related to Server app', 'name': 'App: Server' },

--- a/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.html
+++ b/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.html
@@ -1,4 +1,4 @@
-<div class="page-content">
+<div class="forecast page-content">
   <div class="viewer-container slide-in" [class.active]="viewerOpen() ? true : false">
     <forecast-viewer [forecast]="viewerForecast()" (closeClicked)="viewerOpen.set(false)" />
   </div>
@@ -8,6 +8,7 @@
     [countryCode]="countryCode()"
     [value]="locationSelected()"
     (valueChanged)="handleLocationUpdate($event)"
+    [fieldTitle]="true"
   ></picsa-form-location-select>
 
   <!-- Short Term (Weekly + Daily) -->

--- a/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.html
+++ b/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.html
@@ -1,4 +1,4 @@
-<div class="forecast page-content">
+<div class="forecast-page page-content">
   <div class="viewer-container slide-in" [class.active]="viewerOpen() ? true : false">
     <forecast-viewer [forecast]="viewerForecast()" (closeClicked)="viewerOpen.set(false)" />
   </div>
@@ -11,116 +11,203 @@
     [fieldTitle]="true"
   ></picsa-form-location-select>
 
-  <!-- Short Term (Weekly + Daily) -->
-  <h2>{{'Short Term' | translate}}</h2>
-  <div class="w-full">
-    @if (loading() && dailyForecasts().length === 0 && weeklyForecasts().length === 0) {
-      <div class="mx-auto w-24 mt-4 mb-2">
-        <mat-progress-bar mode="query"></mat-progress-bar>
+  <!-- Toolbar: title + sync status + force refresh -->
+  <div class="forecast-toolbar">
+    <div class="forecast-toolbar__title">Available Forecasts</div>
+    <div class="forecast-toolbar__actions">
+      <!-- Sync status indicator -->
+      <div class="sync-status" [attr.data-state]="syncStatus().state">
+        @if (syncing()) {
+        <mat-spinner class="sync-status__spinner" [diameter]="18"></mat-spinner>
+        } @else {
+        <mat-icon class="sync-status__icon">{{ syncStatus().icon }}</mat-icon>
+        }
+        <div class="sync-status__text">
+          <span class="sync-status__label">{{ syncStatus().label | translate }}</span>
+          <!-- <span class="sync-status__detail">({{ syncStatus().detail | translate }})</span> -->
+        </div>
       </div>
-    } @else if (loading()) {
-      <mat-progress-bar mode="indeterminate" class="h-1 mb-2"></mat-progress-bar>
-    } @else {
-      <div class="h-1 mb-2"></div>
-    }
-
-    <div class="flex flex-wrap items-center gap-4 w-full">
-      @if (!countryCode()) {
-        <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
-          {{ 'Please select a location to view forecasts' | translate }}
-        </div>
-      } @else if (dailyForecasts().length === 0 && weeklyForecasts().length === 0) {
-        <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
-          {{ 'No short term forecasts found' | translate }}
-        </div>
-      } @else {
-        @for(forecast of weeklyForecasts(); track forecast.id){
-          <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
+      <!-- Force refresh -->
+      <button
+        matButton="filled"
+        color="primary"
+        class="force-refresh-button"
+        [disabled]="syncing() || !locationReady() || syncStatus().state === 'offline'"
+        (click)="handleForceRefresh()"
+      >
+        <span>{{ 'Force Refresh' | translate }}</span>
+        @if (syncing()) {
+        <mat-spinner [diameter]="18" class="force-refresh-button__spinner"></mat-spinner>
+        } @else {
+        <mat-icon>refresh</mat-icon>
         }
-        @for(forecast of dailyForecasts(); track forecast.id){
-          <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
-        }
+      </button>
+      <!-- Inline offline/error notification (cached data kept intact) -->
+      @if (syncErrorMessage(); as errorMessage) {
+      <div class="sync-banner" [attr.data-state]="syncStatus().state">
+        <div><mat-icon>{{ syncStatus().state === 'offline' ? 'cloud_off' : 'error_outline' }}</mat-icon></div>
+        <span>{{ errorMessage | translate }}</span>
+        <div><mat-icon>close</mat-icon></div>
+        <!-- <button matButton color="primary" (click)="handleForceRefresh()" [disabled]="syncing()">
+      {{ 'Retry' | translate }}
+    </button> -->
+      </div>
       }
     </div>
-  </div>
-
-  <!-- Seasonal Forecasts -->
-  <h2>{{'Seasonal' | translate}}</h2>
-  <div class="w-full">
-    @if ((loading() || loadingDownscaled()) && downscaledForecasts().length === 0 && seasonalForecasts().length === 0) {
-      <div class="mx-auto w-24 mt-4 mb-2">
-        <mat-progress-bar mode="query"></mat-progress-bar>
+    <section class="forecast-step">
+      @if (!locationReady()) {
+      <div class="forecast-placeholder">
+        <mat-icon>place</mat-icon>
+        <span>{{ 'Please select a province / district to view forecasts' | translate }}</span>
       </div>
-    } @else if (loading() || loadingDownscaled()) {
-      <mat-progress-bar mode="indeterminate" class="h-1 mb-2"></mat-progress-bar>
-    } @else {
-      <div class="h-1 mb-2"></div>
-    }
-
-    <div class="mt-2 flex flex-wrap items-center gap-4 w-full">
-      @if (!countryCode()) {
-        <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
-          {{ 'Please select a location to view forecasts' | translate }}
-        </div>
-      } @else if (downscaledForecasts().length === 0 && seasonalForecasts().length === 0) {
-        <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
-          {{ 'No seasonal forecasts found' | translate }}
-        </div>
       } @else {
-        <!-- Downscaled -->
-        @for(forecast of downscaledForecasts(); track forecast.id){
-          <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
-        }
-        <!-- National -->
-        @for(forecast of seasonalForecasts(); track forecast.id){
-          <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
-        }
+      <!-- Short Term (Weekly + Daily) -->
+      <h3 class="forecast-group-title">{{ 'Short Term' | translate }}</h3>
+      @for (category of shortTermCategories(); track category.id) {
+      <ng-container *ngTemplateOutlet="categorySection; context: { $implicit: category }"></ng-container>
       }
-    </div>
+      <!-- Seasonal (Downscaled + National) -->
+      <h3 class="forecast-group-title">{{ 'Seasonal' | translate }}</h3>
+      @for (category of seasonalCategories(); track category.id) {
+      <ng-container *ngTemplateOutlet="categorySection; context: { $implicit: category }"></ng-container>
+      } }
+    </section>
   </div>
 
   <!-- Resources -->
-  <h2>{{'Resources' | translate}}</h2>
-  <div class="flex flex-wrap gap-4 mb-4">
-    @for(resource of resourceLinks(); track resource.id){
-    <resource-item-link [resource]="resource" class="max-w-80"> </resource-item-link>
-    }
+  <div class="resources">
+    <h3 class="forecast-group-title">{{'Resources' | translate}}</h3>
+    <div class="flex flex-wrap gap-4 mb-4">
+      @if (resourceLinks().length === 0) {
+      <div class="forecast-empty">{{ 'No resources available' | translate }}</div>
+      } @else { @for(resource of resourceLinks(); track resource.id){
+      <resource-item-link [resource]="resource" class="max-w-80"> </resource-item-link>} }
+    </div>
   </div>
+
+  <!-- Category section template: always rendered, empty-state when no data -->
+  <ng-template #categorySection let-value>
+    @if (toCategory(value); as category) {
+    <div class="forecast-category">
+      <div class="forecast-category__header">
+        <h4>{{ category.title | translate }}</h4>
+        @if (category.loading) {
+        <mat-spinner [diameter]="16"></mat-spinner>
+        }
+      </div>
+
+      @if (category.loading && category.forecasts.length === 0) {
+      <mat-progress-bar mode="indeterminate" class="h-1 mb-2"></mat-progress-bar>
+      } @if (category.forecasts.length === 0) {
+      <div class="forecast-empty">{{ 'No forecasts available' | translate }}</div>
+      } @else {
+      <div class="flex flex-wrap items-stretch gap-4 w-full">
+        @for (forecast of category.forecasts; track forecast.id) {
+        <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
+        }
+      </div>
+      }
+    </div>
+    }
+  </ng-template>
 </div>
 
-<!-- Forecast item tempalte -->
+<!-- Forecast item template -->
 <ng-template #forecastItem let-value>
   <!-- use function to make template type-safe -->
-  @if(toForecastType(value); as forecast){
+  @if (toForecastType(value); as forecast) {
   <div
-    class="min-w-40 w-40 h-44 flex flex-col cursor-pointer border border-solid border-[var(--color-secondary-950)]"
+    class="min-w-40 w-40 h-44 flex flex-col cursor-pointer border border-solid border-slate-400 bg-white"
     (click)="handleForecastClick(forecast)"
   >
-    <h3 class="forecast-heading">{{forecast.title | translate}}</h3>
+    <h3 class="forecast-heading">{{ forecast.title | translate }}</h3>
     <!-- seasonal/downscaled: image + label -->
-    @if(forecast.image){
+    @if (forecast.image) {
     <div class="flex-1 min-h-0">
       <img class="forecast-image" [src]="forecast.image" />
     </div>
-    @if(forecast.label){
-    <div class="p-1 text-center">{{forecast.label}}</div>
+    @if (forecast.label) {
+    <div class="p-1 text-center">{{ forecast.label }}</div>
     } }
     <!-- daily/weekly: label only -->
     @else {
-    <div class="flex-1 p-2 overflow-auto capitalize">{{forecast.label}}</div>
+    <div class="flex-1 p-2 overflow-auto capitalize">{{ forecast.label }}</div>
     }
 
     <div class="forecast-bottom-bar" [attr.data-forecast-type]="forecast.type">
-      <div class="language-label">{{forecast.languageLabel}}</div>
+      <div class="language-label">{{ forecast.languageLabel }}</div>
+      <span class="forecast-format">PDF</span>
       <picsa-supabase-storage-download [storage_path]="forecast.storage_file" #downloader (click)="downloader.stop()">
       </picsa-supabase-storage-download>
 
-      <mat-icon>{{forecast.downloaded || downloader.progress()===100 ? 'task_alt' : 'download'}}</mat-icon>
+      <mat-icon>{{ forecast.downloaded || downloader.progress() === 100 ? 'task_alt' : 'download' }}</mat-icon>
 
-      @if(downloader.progress()){
+      @if (downloader.progress()) {
       <mat-progress-bar [value]="downloader.progress()"> </mat-progress-bar>
       }
     </div>
   </div>
   }
 </ng-template>
+
+<!-- Short Term (Weekly + Daily) -->
+<!-- <h2>{{'Short Term' | translate}}</h2>
+<div class="w-full">
+  @if (loading() && dailyForecasts().length === 0 && weeklyForecasts().length === 0) {
+  <div class="mx-auto w-24 mt-4 mb-2">
+    <mat-progress-bar mode="query"></mat-progress-bar>
+  </div>
+  } @else if (loading()) {
+  <mat-progress-bar mode="indeterminate" class="h-1 mb-2"></mat-progress-bar>
+  } @else {
+  <div class="h-1 mb-2"></div>
+  }
+
+  <div class="flex flex-wrap items-center gap-4 w-full">
+    @if (!countryCode()) {
+    <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
+      {{ 'Please select a location to view forecasts' | translate }}
+    </div>
+    } @else if (dailyForecasts().length === 0 && weeklyForecasts().length === 0) {
+    <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
+      {{ 'No short term forecasts found' | translate }}
+    </div>
+    } @else { @for(forecast of weeklyForecasts(); track forecast.id){
+    <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
+    } @for(forecast of dailyForecasts(); track forecast.id){
+    <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
+    } }
+  </div>
+</div> -->
+
+<!-- Seasonal Forecasts -->
+<!-- <h2>{{'Seasonal' | translate}}</h2>
+<div class="w-full">
+  @if ((loading() || loadingDownscaled()) && downscaledForecasts().length === 0 && seasonalForecasts().length === 0) {
+  <div class="mx-auto w-24 mt-4 mb-2">
+    <mat-progress-bar mode="query"></mat-progress-bar>
+  </div>
+  } @else if (loading() || loadingDownscaled()) {
+  <mat-progress-bar mode="indeterminate" class="h-1 mb-2"></mat-progress-bar>
+  } @else {
+  <div class="h-1 mb-2"></div>
+  }
+
+  <div class="mt-2 flex flex-wrap items-center gap-4 w-full">
+    @if (!countryCode()) {
+    <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
+      {{ 'Please select a location to view forecasts' | translate }}
+    </div>
+    } @else if (downscaledForecasts().length === 0 && seasonalForecasts().length === 0) {
+    <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
+      {{ 'No seasonal forecasts found' | translate }}
+    </div>
+    } @else {
+    @for(forecast of downscaledForecasts(); track forecast.id){
+    <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
+    }
+    @for(forecast of seasonalForecasts(); track forecast.id){
+    <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
+    } }
+  </div>
+</div> -->

--- a/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.html
+++ b/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.html
@@ -3,6 +3,19 @@
     <forecast-viewer [forecast]="viewerForecast()" (closeClicked)="viewerOpen.set(false)" />
   </div>
 
+  <!-- Inline offline/error notification -->
+  @if (showBanner() && locationReady()) {
+  <div class="sync-banner" [attr.data-state]="syncStatus().state">
+    <div>
+      <mat-icon>{{ syncStatus().state === 'offline' ? 'cloud_off' : 'error_outline' }}</mat-icon>
+    </div>
+    @if(syncErrorMessage()){<span>{{ syncErrorMessage()! | translate }}</span>}
+    <button type="button" class="sync-banner__close" (click)="closeBanner()" [attr.aria-label]="'Close' | translate">
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
+  }
+
   <!-- Location Select  -->
   <picsa-form-location-select
     [countryCode]="countryCode()"
@@ -13,44 +26,50 @@
 
   <!-- Toolbar: title + sync status + force refresh -->
   <div class="forecast-toolbar">
-    <div class="forecast-toolbar__title">Available Forecasts</div>
+    <div class="forecast-toolbar__title capitalize">{{ 'Available Forecasts' | translate }}</div>
     <div class="forecast-toolbar__actions">
-      <!-- Sync status indicator -->
-      <div class="sync-status" [attr.data-state]="syncStatus().state">
-        @if (syncing()) {
-        <mat-spinner class="sync-status__spinner" [diameter]="18"></mat-spinner>
-        } @else {
-        <mat-icon class="sync-status__icon">{{ syncStatus().icon }}</mat-icon>
-        }
-        <div class="sync-status__text">
-          <span class="sync-status__label">{{ syncStatus().label | translate }}</span>
-          <!-- <span class="sync-status__detail">({{ syncStatus().detail | translate }})</span> -->
+      @if(locationReady()){
+      <div class="flex flex-row justify-between items-center gap-2">
+        <!-- Sync status indicator -->
+        <div class="sync-status flex flex-col" [attr.data-state]="syncStatus().state">
+          <div class="flex flex-row items-center gap-1">
+            @if (syncing()) {
+            <div>
+              <mat-spinner class="sync-status__spinner" [diameter]="18"></mat-spinner>
+            </div>
+            } @else {
+            <div>
+              <mat-icon class="sync-status__icon">{{ syncStatus().icon }}</mat-icon>
+            </div>
+            }
+            <span class="sync-status__text sync-status__label text-center">{{ syncStatus().label | translate }}</span>
+          </div>
+          <div class="sync-status__text w-full">
+            @if (syncStatus().detail) {
+            <span class="sync-status__detail">({{ syncStatus().detail! | translate }})</span>
+            }
+          </div>
         </div>
+        <!-- Force refresh -->
+        <button
+          matButton="filled"
+          color="primary"
+          class="force-refresh-button"
+          [disabled]="syncing() || !locationReady() || syncStatus().state === 'offline' || syncStatus().state === 'success'"
+          (click)="handleForceRefresh()"
+        >
+          @if (syncing()) {
+          <mat-spinner [diameter]="18" class="force-refresh-button__spinner"></mat-spinner>
+          } @else {
+          <mat-icon>refresh</mat-icon>
+          }
+          <span>{{ 'Refresh' | translate }}</span>
+        </button>
       </div>
-      <!-- Force refresh -->
-      <button
-        matButton="filled"
-        color="primary"
-        class="force-refresh-button"
-        [disabled]="syncing() || !locationReady() || syncStatus().state === 'offline'"
-        (click)="handleForceRefresh()"
-      >
-        <span>{{ 'Force Refresh' | translate }}</span>
-        @if (syncing()) {
-        <mat-spinner [diameter]="18" class="force-refresh-button__spinner"></mat-spinner>
-        } @else {
-        <mat-icon>refresh</mat-icon>
-        }
-      </button>
-      <!-- Inline offline/error notification (cached data kept intact) -->
-      @if (syncErrorMessage(); as errorMessage) {
-      <div class="sync-banner" [attr.data-state]="syncStatus().state">
-        <div><mat-icon>{{ syncStatus().state === 'offline' ? 'cloud_off' : 'error_outline' }}</mat-icon></div>
-        <span>{{ errorMessage | translate }}</span>
-        <div><mat-icon>close</mat-icon></div>
-        <!-- <button matButton color="primary" (click)="handleForceRefresh()" [disabled]="syncing()">
-      {{ 'Retry' | translate }}
-    </button> -->
+      } @else{
+      <div class="sync-status flex flex-row items-center justify-center">
+        <mat-icon class="sync-status__icon">place</mat-icon>
+        <span>{{ 'No location selected' | translate }}</span>
       </div>
       }
     </div>
@@ -76,7 +95,7 @@
 
   <!-- Resources -->
   <div class="resources">
-    <h3 class="forecast-group-title">{{'Resources' | translate}}</h3>
+    <h3 class="forecast-group-title capitalize">{{'Resources' | translate}}</h3>
     <div class="flex flex-wrap gap-4 mb-4">
       @if (resourceLinks().length === 0) {
       <div class="forecast-empty">{{ 'No resources available' | translate }}</div>
@@ -99,7 +118,7 @@
       @if (category.loading && category.forecasts.length === 0) {
       <mat-progress-bar mode="indeterminate" class="h-1 mb-2"></mat-progress-bar>
       } @if (category.forecasts.length === 0) {
-      <div class="forecast-empty">{{ 'No forecasts available' | translate }}</div>
+      <div class="forecast-empty capitalize">{{ 'No forecasts available' | translate }}</div>
       } @else {
       <div class="flex flex-wrap items-stretch gap-4 w-full">
         @for (forecast of category.forecasts; track forecast.id) {
@@ -149,65 +168,3 @@
   </div>
   }
 </ng-template>
-
-<!-- Short Term (Weekly + Daily) -->
-<!-- <h2>{{'Short Term' | translate}}</h2>
-<div class="w-full">
-  @if (loading() && dailyForecasts().length === 0 && weeklyForecasts().length === 0) {
-  <div class="mx-auto w-24 mt-4 mb-2">
-    <mat-progress-bar mode="query"></mat-progress-bar>
-  </div>
-  } @else if (loading()) {
-  <mat-progress-bar mode="indeterminate" class="h-1 mb-2"></mat-progress-bar>
-  } @else {
-  <div class="h-1 mb-2"></div>
-  }
-
-  <div class="flex flex-wrap items-center gap-4 w-full">
-    @if (!countryCode()) {
-    <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
-      {{ 'Please select a location to view forecasts' | translate }}
-    </div>
-    } @else if (dailyForecasts().length === 0 && weeklyForecasts().length === 0) {
-    <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
-      {{ 'No short term forecasts found' | translate }}
-    </div>
-    } @else { @for(forecast of weeklyForecasts(); track forecast.id){
-    <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
-    } @for(forecast of dailyForecasts(); track forecast.id){
-    <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
-    } }
-  </div>
-</div> -->
-
-<!-- Seasonal Forecasts -->
-<!-- <h2>{{'Seasonal' | translate}}</h2>
-<div class="w-full">
-  @if ((loading() || loadingDownscaled()) && downscaledForecasts().length === 0 && seasonalForecasts().length === 0) {
-  <div class="mx-auto w-24 mt-4 mb-2">
-    <mat-progress-bar mode="query"></mat-progress-bar>
-  </div>
-  } @else if (loading() || loadingDownscaled()) {
-  <mat-progress-bar mode="indeterminate" class="h-1 mb-2"></mat-progress-bar>
-  } @else {
-  <div class="h-1 mb-2"></div>
-  }
-
-  <div class="mt-2 flex flex-wrap items-center gap-4 w-full">
-    @if (!countryCode()) {
-    <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
-      {{ 'Please select a location to view forecasts' | translate }}
-    </div>
-    } @else if (downscaledForecasts().length === 0 && seasonalForecasts().length === 0) {
-    <div class="p-4 text-[var(--color-secondary-600)] italic w-full text-center">
-      {{ 'No seasonal forecasts found' | translate }}
-    </div>
-    } @else {
-    @for(forecast of downscaledForecasts(); track forecast.id){
-    <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
-    }
-    @for(forecast of seasonalForecasts(); track forecast.id){
-    <ng-container *ngTemplateOutlet="forecastItem; context: { $implicit: forecast }"></ng-container>
-    } }
-  </div>
-</div> -->

--- a/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.scss
+++ b/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.scss
@@ -1,7 +1,6 @@
 .page-content {
   max-width: 1280px;
-  margin: auto;
-  width: 100%;
+  margin: auto 12px;
 }
 .forecast-container {
   @apply border-solid capitalize p-2;
@@ -56,4 +55,29 @@ h2 {
 }
 .forecast-image {
   @apply h-full w-full object-contain;
+}
+
+.forecast {
+  & > picsa-form-location-select {
+    ::ng-deep {
+      .form-location-select {
+        .mat-mdc-form-field {
+          width: 100%;
+        }
+      }
+    }
+  }
+}
+
+@media only screen and (max-width: 480px) {
+  .forecast {
+    & > picsa-form-location-select {
+      ::ng-deep {
+        .form-location-select {
+          display: flex;
+          flex-direction: column;
+        }
+      }
+    }
+  }
 }

--- a/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.scss
+++ b/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.scss
@@ -1,6 +1,7 @@
 .page-content {
   max-width: 1280px;
-  margin: auto 12px;
+  padding: unset;
+  margin: 16px 0;
 }
 .forecast-container {
   @apply border-solid capitalize p-2;
@@ -57,20 +58,28 @@ h2 {
   @apply h-full w-full object-contain;
 }
 
-.forecast {
+.forecast-page {
   & > picsa-form-location-select {
     ::ng-deep {
       .form-location-select {
+        margin: auto 12px;
         .mat-mdc-form-field {
           width: 100%;
         }
       }
     }
   }
+  .resources {
+    margin: 0 16px;
+  }
+}
+
+button span.mdc-button__label {
+  width: unset;
 }
 
 @media only screen and (max-width: 480px) {
-  .forecast {
+  .forecast-page {
     & > picsa-form-location-select {
       ::ng-deep {
         .form-location-select {
@@ -80,4 +89,192 @@ h2 {
       }
     }
   }
+}
+
+.forecast-toolbar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 1rem 1rem 1.5rem 1rem;
+  background-color: var(--color-secondary-50);
+  border-top: 1px solid var(--color-secondary-200);
+
+  &__title {
+    margin: 0;
+    font-size: 1.4rem;
+    font-weight: 600;
+    text-align: center;
+    width: 100%;
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    width: 100%;
+
+    .force-refresh-button {
+      width: 90%;
+      border-radius: 20px;
+
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+  }
+
+  .forecast-group-title {
+    text-transform: uppercase;
+    font-weight: 500;
+    opacity: 0.7;
+  }
+}
+
+.sync-status {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
+  background: var(--color-secondary-100, #f1f1f1);
+  color: var(--color-secondary-800, #444);
+
+  &__detail {
+    opacity: 0.75;
+    margin-left: 0.25rem;
+  }
+
+  &__text {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+  }
+
+  &__icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+
+  &[data-state='success'] {
+    color: var(--ion-color-success, #2e7d32);
+  }
+  &[data-state='stale'] {
+    color: var(--ion-color-primary-tint, #b26a00);
+  }
+  &[data-state='offline'],
+  &[data-state='error'] {
+    color: var(--ion-color-danger, #c62828);
+  }
+  &[data-state='updating'] .sync-status__icon {
+    animation: forecast-spin 1.2s linear infinite;
+  }
+}
+
+@keyframes forecast-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.force-refresh-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+
+  &__spinner {
+    display: inline-block;
+  }
+}
+
+.sync-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  margin-bottom: 0.75rem;
+  border-radius: 6px;
+  background: #fff4e5;
+  color: #8a5300;
+
+  &[data-state='error'] {
+    background: #fdecea;
+    color: var(--ion-color-danger, #c62828);
+  }
+}
+
+.forecast-group-title {
+  margin: 1rem 0 0.25rem;
+}
+
+.forecast-category {
+  margin-bottom: 1rem;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    h4 {
+      margin: 0.25rem 0;
+      text-transform: capitalize;
+    }
+  }
+}
+
+.forecast-step {
+  margin-bottom: 1.5rem;
+  width: 100%;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    h2 {
+      margin: 0;
+    }
+  }
+  &__number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 50%;
+    background: var(--color-primary, #0d6b3f);
+    color: #fff;
+    font-size: 0.875rem;
+  }
+}
+
+.forecast-empty,
+.forecast-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  font-style: italic;
+  color: var(--color-secondary-600);
+  border: 1px dashed var(--color-secondary-300, #ccc);
+  border-radius: 6px;
+}
+
+.forecast-format {
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  padding: 0 0.25rem;
+  border-radius: 3px;
+  background: rgba(0, 0, 0, 0.12);
 }

--- a/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.scss
+++ b/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.scss
@@ -88,6 +88,9 @@ button span.mdc-button__label {
         }
       }
     }
+    .sync-status {
+      max-width: 240px;
+    }
   }
 }
 
@@ -111,20 +114,9 @@ button span.mdc-button__label {
 
   &__actions {
     display: flex;
-    justify-content: center;
+    flex-direction: column;
     align-items: center;
     gap: 0.75rem;
-    flex-wrap: wrap;
-    width: 100%;
-
-    .force-refresh-button {
-      width: 90%;
-      border-radius: 20px;
-
-      display: flex;
-      justify-content: center;
-      align-items: center;
-    }
   }
 
   .forecast-group-title {
@@ -137,16 +129,17 @@ button span.mdc-button__label {
 .sync-status {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.075rem;
   font-size: 0.8125rem;
-  padding: 0.25rem 0.625rem;
+  padding: 0.425rem 2rem;
   border-radius: 999px;
-  background: var(--color-secondary-100, #f1f1f1);
+  background: var(--ion-color-secondary-100, #c1c1c1);
   color: var(--color-secondary-800, #444);
 
   &__detail {
     opacity: 0.75;
     margin-left: 0.25rem;
+    color: var(--ion-color-dark);
   }
 
   &__text {
@@ -163,13 +156,16 @@ button span.mdc-button__label {
 
   &[data-state='success'] {
     color: var(--ion-color-success, #2e7d32);
+    background: var(--ion-color-secondary-100, #edfff2);
   }
   &[data-state='stale'] {
     color: var(--ion-color-primary-tint, #b26a00);
+    background: var(--ion-color-secondary-100, #fff4e5);
   }
   &[data-state='offline'],
   &[data-state='error'] {
     color: var(--ion-color-danger, #c62828);
+    background: var(--ion-color-secondary-100, #fdecea);
   }
   &[data-state='updating'] .sync-status__icon {
     animation: forecast-spin 1.2s linear infinite;
@@ -186,9 +182,12 @@ button span.mdc-button__label {
 }
 
 .force-refresh-button {
-  display: inline-flex;
+  display: flex;
+  flex-direction: row;
+  justify-items: center;
   align-items: center;
-  gap: 0.375rem;
+  padding: 8px 18px;
+  min-width: 100px;
 
   &__spinner {
     display: inline-block;
@@ -209,6 +208,12 @@ button span.mdc-button__label {
   &[data-state='error'] {
     background: #fdecea;
     color: var(--ion-color-danger, #c62828);
+  }
+
+  &__close {
+    background: none;
+    border: none;
+    color: inherit;
   }
 }
 

--- a/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.ts
+++ b/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.ts
@@ -7,10 +7,14 @@ import {
   inject,
   OnDestroy,
   signal,
+  untracked,
   viewChildren,
 } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { marker as translateMarker } from '@biesbjerg/ngx-translate-extract-marker';
 import { ConfigurationService } from '@picsa/configuration/src';
 import { CLIMATE_RESOURCES } from '@picsa/data/climate/resources';
@@ -29,7 +33,16 @@ import { ForecastViewerComponent } from '../../components/forecast-viewer/foreca
 import { IForecast } from '../../schemas';
 import { ForecastService } from '../../services/forecast.service';
 
-const STRINGS = { National: translateMarker('National') };
+const STRINGS = {
+  National: translateMarker('National'),
+  NoData: translateMarker('No data available'),
+  UpToDate: translateMarker('Up to date'),
+  Stale: translateMarker('Stale data'),
+  Checking: translateMarker('Checking for updates…'),
+  Offline: translateMarker('Offline - showing saved forecasts'),
+  Error: translateMarker('Could not check for updates'),
+  NeverSynced: translateMarker('No data Available'),
+};
 
 interface IForecastSummary {
   _doc: RxDocument<IForecast>;
@@ -43,6 +56,22 @@ interface IForecastSummary {
   languageLabel?: string;
 }
 
+interface IForecastCategory {
+  id: string;
+  title: string;
+  forecasts: IForecastSummary[];
+  loading: boolean;
+}
+
+interface ISyncStatus {
+  state: 'idle' | 'updating' | 'success' | 'stale' | 'offline' | 'error';
+  icon: string;
+  label: string;
+  /** e.g. `Last checked: 2 hours ago` */
+  detail?: string;
+}
+
+const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './forecast.page.html',
@@ -50,8 +79,10 @@ interface IForecastSummary {
   imports: [
     CommonModule,
     ForecastViewerComponent,
+    MatButtonModule,
     MatIcon,
     MatProgressBarModule,
+    MatProgressSpinnerModule,
     PicsaFormsModule,
     PicsaTranslateModule,
     ResourceItemLinkComponent,
@@ -61,6 +92,7 @@ interface IForecastSummary {
 export class ForecastComponent implements OnDestroy {
   private service = inject(ForecastService);
   private configurationService = inject(ConfigurationService);
+  private snackbar = inject(MatSnackBar);
 
   /** Forecast summary for display in forecast-viewer component */
   public viewerForecast = signal<IForecastSummary | undefined>(undefined);
@@ -74,8 +106,17 @@ export class ForecastComponent implements OnDestroy {
   public downscaledForecasts = computed(() => this.generateForecastSummary(this.service.downscaledForecastDocs()));
   public seasonalForecasts = computed(() => this.generateForecastSummary(this.service.seasonalForecastDocs()));
 
+  public locationReady = computed(() => {
+    const location = this.locationSelected() || [];
+    return !!location[2] && !!location[4];
+  });
+
   public loading = computed(() => this.service.loadingForecasts());
   public loadingDownscaled = computed(() => this.service.loadingDownscaled());
+
+  // Activity that should render the animated spinner
+  public refreshing = computed(() => this.service.isForceRefreshing());
+  public syncing = computed(() => this.loading() || this.loadingDownscaled() || this.refreshing());
 
   public resourceLinks = computed<IResourceLink[]>(() => {
     const { country_code } = this.configurationService.userSettings();
@@ -84,14 +125,84 @@ export class ForecastComponent implements OnDestroy {
 
   // Utility to add type-safety to implicit ng-template data
   public toForecastType = (data: any) => data as IForecastSummary;
+  public toCategory = (data: any) => data as IForecastCategory;
 
   /** List of rendered SupabaseStorageDownload components for direct interaction */
   private downloaders = viewChildren(SupabaseStorageDownloadComponent);
+
+  /** Categories are always rendered - each falls back to "No data available" */
+  public shortTermCategories = computed<IForecastCategory[]>(() => [
+    { id: 'weekly', title: translateMarker('Weekly'), forecasts: this.weeklyForecasts(), loading: this.loading() },
+    { id: 'daily', title: translateMarker('Daily'), forecasts: this.dailyForecasts(), loading: this.loading() },
+  ]);
+
+  public seasonalCategories = computed<IForecastCategory[]>(() => [
+    {
+      id: 'downscaled',
+      title: translateMarker('Downscaled'),
+      forecasts: this.downscaledForecasts(),
+      loading: this.loadingDownscaled(),
+    },
+    {
+      id: 'seasonal',
+      title: translateMarker('National'),
+      forecasts: this.seasonalForecasts(),
+      loading: this.loading(),
+    },
+  ]);
+
+  /** Ticking clock used to keep relative "x hours ago" labels fresh */
+  private now = signal(Date.now());
+  private nowInterval = setInterval(() => this.now.set(Date.now()), 30_000);
+
+  public syncStatus = computed<ISyncStatus>(() => {
+    const state = this.service.syncState();
+    const lastSyncedAt = this.service.lastSyncedAt();
+    const now = this.now();
+
+    const detail = lastSyncedAt
+      ? `${translateMarker('Last checked')}: ${formatRelativeTime(new Date(lastSyncedAt).getTime(), now)}`
+      : STRINGS.NeverSynced;
+
+    if (this.syncing()) {
+      return { state: 'updating', icon: 'sync', label: STRINGS.Checking, detail };
+    }
+    if (state === 'offline') {
+      return { state: 'offline', icon: 'cloud_off', label: STRINGS.Offline };
+    }
+    if (state === 'error') {
+      return { state: 'error', icon: 'error_outline', label: STRINGS.Error };
+    }
+    const isStale = !lastSyncedAt || now - new Date(lastSyncedAt).getTime() > STALE_THRESHOLD_MS;
+    return isStale
+      ? { state: 'stale', icon: 'schedule', label: STRINGS.Stale, detail }
+      : { state: 'success', icon: 'cloud_done', label: STRINGS.UpToDate, detail };
+  });
+
+  /** Inline banner message shown when a refresh fails (cached data is retained) */
+  public syncErrorMessage = computed(() => (this.syncing() ? undefined : this.service.syncError()));
+
+  /** Track last notified error to avoid duplicate toasts */
+  private lastNotifiedError?: string;
 
   constructor() {
     effect(() => {
       const { location } = this.configurationService.userSettings();
       this.service.setForecastLocation(location);
+    });
+    // Toast feedback for offline/error sync states (data remains cached)
+    effect(() => {
+      const state = this.service.syncState();
+      const message = this.service.syncError();
+      untracked(() => {
+        if ((state === 'offline' || state === 'error') && message && message !== this.lastNotifiedError) {
+          this.lastNotifiedError = message;
+          this.snackbar.open(message, undefined, { duration: 4000, panelClass: 'forecast-sync-snackbar' });
+        }
+        if (state === 'success') {
+          this.lastNotifiedError = undefined;
+        }
+      });
     });
   }
 
@@ -101,6 +212,10 @@ export class ForecastComponent implements OnDestroy {
 
   public handleLocationUpdate(location: (string | undefined)[]) {
     this.configurationService.updateUserSettings({ location });
+  }
+
+  public async handleForceRefresh() {
+    await this.service.forceRefresh();
   }
 
   public async handleForecastClick(forecast: IForecastSummary) {
@@ -180,4 +295,15 @@ function storageFileToLabel(storage_file: string) {
     return basename.replace(/[-_]/g, ' ');
   }
   return storage_file;
+}
+
+function formatRelativeTime(from: number, now: number) {
+  const diff = Math.max(0, now - from);
+  const minutes = Math.round(diff / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  const days = Math.round(hours / 24);
+  return `${days} day${days === 1 ? '' : 's'} ago`;
 }

--- a/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.ts
+++ b/apps/picsa-tools/forecasts-tool/src/app/pages/forecast/forecast.page.ts
@@ -66,6 +66,7 @@ interface IForecastCategory {
 interface ISyncStatus {
   state: 'idle' | 'updating' | 'success' | 'stale' | 'offline' | 'error';
   icon: string;
+  /** e.g. `Up to Date`, `Offline` */
   label: string;
   /** e.g. `Last checked: 2 hours ago` */
   detail?: string;
@@ -93,6 +94,7 @@ export class ForecastComponent implements OnDestroy {
   private service = inject(ForecastService);
   private configurationService = inject(ConfigurationService);
   private snackbar = inject(MatSnackBar);
+  readonly dismissedError = signal<string | undefined>(undefined);
 
   /** Forecast summary for display in forecast-viewer component */
   public viewerForecast = signal<IForecastSummary | undefined>(undefined);
@@ -165,7 +167,7 @@ export class ForecastComponent implements OnDestroy {
       : STRINGS.NeverSynced;
 
     if (this.syncing()) {
-      return { state: 'updating', icon: 'sync', label: STRINGS.Checking, detail };
+      return { state: 'updating', icon: 'sync', label: STRINGS.Checking };
     }
     if (state === 'offline') {
       return { state: 'offline', icon: 'cloud_off', label: STRINGS.Offline };
@@ -287,7 +289,18 @@ export class ForecastComponent implements OnDestroy {
     if (label) return label;
     return storageFileToLabel(storage_file);
   }
+
+  // Banner is visible when there's an error that hasn't been dismissed
+  readonly showBanner = computed(() => {
+    const error = this.syncErrorMessage();
+    return !!error && error !== this.dismissedError();
+  });
+
+  closeBanner(): void {
+    this.dismissedError.set(this.syncErrorMessage());
+  }
 }
+
 function storageFileToLabel(storage_file: string) {
   const filename = storage_file.split('/').pop();
   if (filename) {

--- a/apps/picsa-tools/forecasts-tool/src/app/services/forecast.service.ts
+++ b/apps/picsa-tools/forecasts-tool/src/app/services/forecast.service.ts
@@ -1,4 +1,4 @@
-import { effect, inject, Injectable, signal, WritableSignal } from '@angular/core';
+import { computed, effect, inject, Injectable, signal, WritableSignal } from '@angular/core';
 import { IUserSettings } from '@picsa/configuration/src';
 import { ICountryCode } from '@picsa/data';
 import { FORECASTS_DB } from '@picsa/data/climate/forecasts';
@@ -19,6 +19,7 @@ interface IDownscaledLocation {
 }
 
 type ForecastType = 'daily' | 'weekly' | 'seasonal' | 'downscaled';
+export type DataSyncType = 'idle' | 'updating' | 'success' | 'offline' | 'error';
 
 interface LoaderConfig {
   type: ForecastType;
@@ -26,6 +27,19 @@ interface LoaderConfig {
   limit?: number;
   includeStorage?: boolean;
 }
+
+class ForecastOfflineError extends Error {
+  constructor() {
+    super('Forecast server is offline/unavailable');
+  }
+}
+
+interface ILoadOptions {
+  /** Bypass incremental `gt(id)` query bounds and re-validate all recent server records */
+  force?: boolean;
+}
+
+export const FORECAST_STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 
 @Injectable({ providedIn: 'root' })
 export class ForecastService extends PicsaAsyncService {
@@ -48,6 +62,18 @@ export class ForecastService extends PicsaAsyncService {
 
   public loadingForecasts = signal(false);
   public loadingDownscaled = signal(false);
+
+  public syncState = signal<DataSyncType>('idle');
+  public syncError = signal<string | undefined>(undefined);
+
+  private readonly LAST_SYNC_STORAGE_KEY = 'picsa_forecast_last_sync';
+  public lastSyncedAt = signal<string | undefined>(this.readPersistedSyncTime());
+  public isForceRefreshing = signal(false);
+  public isStale = computed(() => {
+    const last = this.lastSyncedAt();
+    if (!last) return true;
+    return Date.now() - new Date(last).getTime() > FORECAST_STALE_THRESHOLD_MS;
+  });
 
   private loaderConfigs: LoaderConfig[] = [
     // TODO - limit not very useful, can have multiple translated versions
@@ -81,6 +107,8 @@ export class ForecastService extends PicsaAsyncService {
         this.seasonalForecastDocs.set([]);
         this.weeklyForecastDocs.set([]);
         this.dailyForecastDocs.set([]);
+        this.loadingForecasts.set(false);
+        this.syncState.set('idle');
         this.loadingForecasts.set(false);
       }
     });
@@ -124,6 +152,25 @@ export class ForecastService extends PicsaAsyncService {
     }
   }
 
+  // Force Refresh for latest forecasts for active country location
+  public async forceRefresh(): Promise<void> {
+    await this.ready();
+    const country_code = this.countryLocation();
+    if (!country_code) {
+      this.syncState.set('idle');
+      return;
+    }
+    // Prevent overlapping manual refreshes
+    if (this.isForceRefreshing()) return;
+
+    this.isForceRefreshing.set(true);
+    try {
+      await this.loadForecastsForCountry(country_code, { force: true });
+    } finally {
+      this.isForceRefreshing.set(false);
+    }
+  }
+
   public async downloadForecastFile(doc: RxDocument<IForecast>, downloaderUI: SupabaseStorageDownloadComponent) {
     await downloaderUI.start();
     const { error, data } = await downloaderUI.completed();
@@ -142,7 +189,10 @@ export class ForecastService extends PicsaAsyncService {
     return doc;
   }
 
-  private async loadForecastsForCountry(country_code: ICountryCode) {
+  private async loadForecastsForCountry(country_code: ICountryCode, options: ILoadOptions = {}) {
+    const { force = false } = options;
+
+    // Cancel any in-flight load (e.g. user switched location mid force-refresh)
     if (this.activeCountryLoad) {
       this.activeCountryLoad.cancelled = true;
     }
@@ -179,11 +229,27 @@ export class ForecastService extends PicsaAsyncService {
       const serverConfigs = countryConfigs.filter((c) => c.includeStorage);
       if (serverConfigs.length > 0) {
         this.loadingForecasts.set(true);
+        this.syncState.set('updating');
+        this.syncError.set(undefined);
+
+        await this.supabaseService.ready();
+        if (!this.supabaseService.isAvailable() || !this.isOnline()) {
+          // Offline - keep cached data intact and surface feedback to the UI
+          if (!currentLoad.cancelled) {
+            this.syncState.set('offline');
+            this.syncError.set('No internet connection. Showing previously downloaded forecasts.');
+          }
+          return;
+        }
 
         await Promise.all(
           serverConfigs.map(async (config) => {
             const cached = config.signal();
-            const serverForecasts = await this.loadServerForecasts(country_code, config.type, cached[0], config.limit);
+            // On force refresh bypass the incremental bound so recent records are re-validated
+            const latest = force ? undefined : cached[0];
+            const serverForecasts = await this.loadServerForecasts(country_code, config.type, latest, config.limit, {
+              force,
+            });
             if (currentLoad.cancelled) return;
 
             if (serverForecasts.length > 0) {
@@ -206,9 +272,23 @@ export class ForecastService extends PicsaAsyncService {
             }
           }),
         );
+
+        // Location switch occurred while refresh was in flight - discard result
+        if (currentLoad.cancelled) return;
+
+        this.markSyncSuccess();
       }
     } catch (err) {
       console.error('[ForecastService] Error loading forecasts', err);
+      if (!currentLoad.cancelled) {
+        const offline = !this.isOnline() || !this.supabaseService.isAvailable();
+        this.syncState.set(offline ? 'offline' : 'error');
+        this.syncError.set(
+          offline
+            ? 'No internet connection. Showing previously downloaded forecasts.'
+            : 'Could not check for new forecasts. Showing previously downloaded forecasts.',
+        );
+      }
     } finally {
       if (!currentLoad.cancelled) {
         this.loadingForecasts.set(false);
@@ -221,6 +301,7 @@ export class ForecastService extends PicsaAsyncService {
     forecast_type: ForecastType,
     latest?: IForecast,
     limit = 3,
+    options: ILoadOptions = {},
   ): Promise<IForecast[]> {
     await this.supabaseService.ready();
     if (!this.supabaseService.isAvailable()) {
@@ -228,13 +309,15 @@ export class ForecastService extends PicsaAsyncService {
       return [];
     }
     const table = this.supabaseService.db.table('forecasts');
-    const query = table.select<'*', IForecastRow>('*').neq('storage_file', null).eq('forecast_type', forecast_type);
+    const query = table.select<'', IForecastRow>('').neq('storage_file', null).eq('forecast_type', forecast_type);
 
     if (country_code !== 'global') {
       query.eq('country_code', country_code);
     }
 
-    if (latest) {
+    // Incremental sync - only fetch records newer than the latest cached record.
+    // Skipped during force refresh so all recent records are re-validated.
+    if (latest && !options.force) {
       query.gt('id', latest.id);
     }
 
@@ -287,15 +370,13 @@ export class ForecastService extends PicsaAsyncService {
   }
 
   private async storeHardcodedData(forecasts: IForecastRow[] = []) {
-    const { error, success } = await this.dbCollection.bulkUpsert(
+    const { error, success } = await this.upsertPreservingAttachments(
       forecasts.map((forecast) => SERVER_DB_MAPPING(forecast)),
     );
-
     if (error.length > 0) {
-      console.error('forecast store error', error);
+      console.error('[ForecastService] error storing hardcoded forecasts', error);
       return [];
     }
-
     return success;
   }
 
@@ -310,6 +391,57 @@ export class ForecastService extends PicsaAsyncService {
   }
 
   private async saveForecasts(forecasts: IForecast[]) {
-    return await this.dbCollection.bulkUpsert(forecasts);
+    return await this.upsertPreservingAttachments(forecasts);
+  }
+
+  /**
+   * Upsert forecast records whilst retaining any RxDB attachments already stored against the document, so that previously downloaded forecast files remain available offline.
+   */
+  private async upsertPreservingAttachments(forecasts: IForecast[]) {
+    if (forecasts.length === 0) {
+      return { success: [] as RxDocument<IForecast>[], error: [] as any[] };
+    }
+    const existingDocs = await this.dbCollection.findByIds(forecasts.map((f) => f.id)).exec();
+
+    const merged = forecasts.map((forecast) => {
+      const existing = existingDocs.get(forecast.id);
+      if (!existing) return forecast;
+      // `toJSON(true)` retains internal `_attachments` metadata required by rxdb
+      const { _attachments } = existing.toJSON(true) as any;
+      if (_attachments && Object.keys(_attachments).length > 0) {
+        return { ...forecast, _attachments } as IForecast;
+      }
+      return forecast;
+    });
+
+    return await this.dbCollection.bulkUpsert(merged as any);
+  }
+
+  private markSyncSuccess() {
+    const timestamp = new Date().toISOString();
+    this.lastSyncedAt.set(timestamp);
+    this.syncError.set(undefined);
+    this.syncState.set('success');
+    this.persistSyncTime(timestamp);
+  }
+
+  private readPersistedSyncTime(): string | undefined {
+    try {
+      return localStorage.getItem(this.LAST_SYNC_STORAGE_KEY) || undefined;
+    } catch (error) {
+      return undefined;
+    }
+  }
+
+  private persistSyncTime(timestamp: string) {
+    try {
+      localStorage.setItem(this.LAST_SYNC_STORAGE_KEY, timestamp);
+    } catch (error) {
+      console.warn('[ForecastService] unable to persist last sync time', error);
+    }
+  }
+
+  private isOnline() {
+    return typeof navigator === 'undefined' ? true : navigator.onLine !== false;
   }
 }

--- a/libs/components/src/components/back-button.component.ts
+++ b/libs/components/src/components/back-button.component.ts
@@ -12,12 +12,13 @@ import { NavigationStackService } from '../services/navStack.service';
   template: `
     @switch (variant) {
       @case ('white') {
-        <button matButton style="color:white" (click)="navStackService.back()">
-          <mat-icon>arrow_back</mat-icon>{{ 'Back' | translate }}
+        <button matButton style="color:white; letterSpacing:-0.1px" (click)="navStackService.back()">
+          <mat-icon style="color:black; backgroundColor:white; padding:8px; borderRadius:50%">arrow_back</mat-icon
+          >{{ 'Back' | translate }}
         </button>
       }
       @default {
-        <button matButton color="primary" (click)="navStackService.back()">
+        <button matButton color="primary" style="letterSpacing:-0.1px" (click)="navStackService.back()">
           <mat-icon>arrow_back</mat-icon>{{ 'Back' | translate }}
         </button>
       }

--- a/libs/components/src/components/picsa-header.component.scss
+++ b/libs/components/src/components/picsa-header.component.scss
@@ -18,9 +18,9 @@ header[data-style='inverted'] {
 }
 
 .start-content {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
+  display: block;
+  position: absolute;
+  left: 0;
   @apply sm:min-w-24;
 }
 
@@ -32,9 +32,9 @@ header[data-style='inverted'] {
 }
 .end-content {
   margin-left: auto;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
+  display: block;
+  position: absolute;
+  right: 0;
   @apply sm:min-w-24;
 }
 h1 {

--- a/libs/forms/components/location-select/location-select.component.html
+++ b/libs/forms/components/location-select/location-select.component.html
@@ -1,30 +1,42 @@
-<div class="flex gap-4 my-4">
+<div class="form-location-select flex gap-1 my-2">
   <!-- Location Select (Admin 4 - district/province) -->
-  @if (locationData().admin_4; as data) {
-    <mat-form-field>
-      <mat-label>{{ data.label }}</mat-label>
-      <mat-select #admin4 (selectionChange)="admin4Selected.set(admin4.value)" [value]="admin4Selected()">
-        @for (option of data.locations; track option.id) {
-          <mat-option [value]="option.id">{{ option.label }}</mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
-  }
+  <div class="flex-col w-full">
+    @if (locationData().admin_4; as data) {
+      @if (fieldTitle() && locationData().admin_5) {
+        <div class="mb-2">Choose a Province</div>
+      } @else if (fieldTitle() && !locationData().admin_5) {
+        <div>Choose a District</div>
+      } @else {}
+      <mat-form-field>
+        <mat-label>{{ data.label }}</mat-label>
+        <mat-select #admin4 (selectionChange)="admin4Selected.set(admin4.value)" [value]="admin4Selected()">
+          @for (option of data.locations; track option.id) {
+            <mat-option [value]="option.id">{{ option.label }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    }
+  </div>
 
   <!-- Location Select (Admin 5) -->
-  @if (locationData().admin_5; as data) {
-    <mat-form-field>
-      <mat-label>{{ data.label }}</mat-label>
-      <mat-select
-        [disabled]="!admin4Selected()"
-        #admin5
-        (selectionChange)="admin5Selected.set(admin5.value)"
-        [value]="admin5Selected()"
-      >
-        @for (option of admin5Options(); track option.id) {
-          <mat-option [value]="option.id">{{ option.label }}</mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
-  }
+  <div class="flex-col w-full">
+    @if (locationData().admin_5; as data) {
+      @if (fieldTitle()) {
+        <div class="mb-2">Choose a District</div>
+      }
+      <mat-form-field>
+        <mat-label>{{ data.label }}</mat-label>
+        <mat-select
+          [disabled]="!admin4Selected()"
+          #admin5
+          (selectionChange)="admin5Selected.set(admin5.value)"
+          [value]="admin5Selected()"
+        >
+          @for (option of admin5Options(); track option.id) {
+            <mat-option [value]="option.id">{{ option.label }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    }
+  </div>
 </div>

--- a/libs/forms/components/location-select/location-select.component.html
+++ b/libs/forms/components/location-select/location-select.component.html
@@ -3,9 +3,9 @@
   <div class="flex-col w-full">
     @if (locationData().admin_4; as data) {
       @if (fieldTitle() && locationData().admin_5) {
-        <div class="mb-2">Choose a Province</div>
+        <div class="form-location-select__label">{{'Choose a Province' | translate}}</div>
       } @else if (fieldTitle() && !locationData().admin_5) {
-        <div>Choose a District</div>
+        <div class="form-location-select__label">{{'Choose a District' | translate}}</div>
       } @else {}
       <mat-form-field>
         <mat-label>{{ data.label }}</mat-label>
@@ -22,7 +22,7 @@
   <div class="flex-col w-full">
     @if (locationData().admin_5; as data) {
       @if (fieldTitle()) {
-        <div class="mb-2">Choose a District</div>
+        <div class="form-location-select__label">{{'Choose a District' | translate}}</div>
       }
       <mat-form-field>
         <mat-label>{{ data.label }}</mat-label>

--- a/libs/forms/components/location-select/location-select.component.scss
+++ b/libs/forms/components/location-select/location-select.component.scss
@@ -1,3 +1,10 @@
 :host {
   display: block;
 }
+
+.form-location-select {
+  &__label {
+    font-size: 1.25rem;
+    padding: 3px;
+  }
+}

--- a/libs/forms/components/location-select/location-select.component.ts
+++ b/libs/forms/components/location-select/location-select.component.ts
@@ -4,6 +4,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { ICountryCode } from '@picsa/data';
 import { getGeoLocationData, IGeolocationData } from '@picsa/data/geoLocation';
+import { PicsaTranslateModule } from '@picsa/i18n';
 import { isEqual } from '@picsa/utils/object.utils';
 
 /**
@@ -20,7 +21,7 @@ import { isEqual } from '@picsa/utils/object.utils';
  */
 @Component({
   selector: 'picsa-form-location-select',
-  imports: [CommonModule, MatFormFieldModule, MatSelectModule],
+  imports: [CommonModule, MatFormFieldModule, MatSelectModule, PicsaTranslateModule],
   templateUrl: './location-select.component.html',
   styleUrl: './location-select.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/forms/components/location-select/location-select.component.ts
+++ b/libs/forms/components/location-select/location-select.component.ts
@@ -30,6 +30,8 @@ export class FormLocationSelectComponent {
 
   public value = input<(string | undefined)[]>([]);
 
+  public fieldTitle = input<boolean | undefined>(false);
+
   /** Optional method to apply to data before rendering locations in list */
   public locationModifier = input<(data: IGeolocationData, countryCode: string) => IGeolocationData>((data) => data);
 


### PR DESCRIPTION
## Developer Summary

> Info for reviewer, e.g. use of ai, pain points/challenges, discussion points for monthly dev call

I used Arena AI to understand the `forecast.service.ts` file and create the initial `forceRefresh()` function. I was able to compare and go through implementations from 4 models. I kept refactoring by choosing what worked and what didn't. 
Html and CSS was largely done AI-free.

Challenges:
- The server was unable to run with node >= 22 and only worked when I switched to node >= 24. It didn't generate an ANON key or allow for a reset. Might need new instructions on how to run.

## Related Issues

> Link any related issues (e.g., `Closes #[issue_number]`, `Relates to #[issue_number]`)

Closes #665 

## Screenshots / Videos

> Include at least 1-2 screenshots of videos if visual changes

<img width="200" src="https://github.com/user-attachments/assets/e6d4e9c3-092b-4bf6-bad9-5029eab690fc" />

| Label | Images |
|------|--------|
| `No location selected` | <img width="200" src="https://github.com/user-attachments/assets/52cdcd74-5f53-4668-897d-3c7c33701039" /> <img width="200" src="https://github.com/user-attachments/assets/f93f19d9-4b30-4e39-895b-42f86cb70185" /> |
| `Offline` | <img width="200" src="https://github.com/user-attachments/assets/43cf925c-acb8-41ad-84f5-f858878446b6" />|
| `Up to date` | <img width="200" src="https://github.com/user-attachments/assets/659f4862-86f2-4aa1-a897-f70a8e3cb9c2" /> <img width="200" src="https://github.com/user-attachments/assets/90df00fb-851f-42b2-851c-4e0dc289c760" /> |

## AI Summary

> Will be generated on PR open. Regenerate by typing comment `/describe` in PR
> More info at https://docs.pr-agent.ai/tools/describe/

### Description

### 🤖 Generated by PR Agent at a461ed8be9f660ad9b1697c4aafd113dfa7cc2f8

- Added manual `forceRefresh()` action to `ForecastService`
- Added sync state tracking and last-synced persistence
- Added refresh button, sync status, and offline banner in UI
- Preserved RxDB attachments during force-refresh upserts


### Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>forecast.service.ts</strong><dd><code>Add forceRefresh sync state and attachment-preserving upserts</code></dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/680/files#diff-8eb5cf9fe1edd9356fdd710a220a9d9881141b0d81a106120435e38dee536529">+142/-10</a></td>

</tr>

<tr>
  <td><strong>forecast.page.ts</strong><dd><code>Add sync status, banner, categories and refresh handler</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/680/files#diff-54fe93d130212398d4e166c80ed685298cff24654cf666737f9075dcd29e5d42">+140/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>forecast.page.html</strong><dd><code>Add toolbar refresh button and status indicator UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/680/files#diff-2b8507db7c93828a9634c69486f28b56c3eb80f22553325872e7ad67a41a13b9">+119/-74</a></td>

</tr>

<tr>
  <td><strong>location-select.component.ts</strong><dd><code>Add optional field title input to location select</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/680/files#diff-644049db7502096248063cd6c85acc78e01bc8bd3cb585b49edb99dacc722fc8">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>location-select.component.html</strong><dd><code>Add field title labels to location selects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/680/files#diff-b0a8ded9b7503893f44b4ccd2a19120bf452d6608c6ad8ffaf80a003889ed6e0">+38/-26</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>forecast.page.scss</strong><dd><code>Style toolbar sync status and refresh button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/680/files#diff-0a14bdc7ff181eca1af859dd4503a21a3d90e52757a71fbbbf19912fce9c446e">+228/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>back-button.component.ts</strong><dd><code>Make back button icon more prominent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/680/files#diff-f193e8356c1e7bc40fd9887dd3c8d9de740c94beb199083b5dbb6b883d7924cd">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>picsa-header.component.scss</strong><dd><code>Reposition header start and end content</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/680/files#diff-f24c781051fa27cfd86f874c539b074396cbf0e358feff20f4811252a2bd154f">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>location-select.component.scss</strong><dd><code>Style location select field title label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/680/files#diff-251be6964a355d70c6d04ae9b90f5174aab59b09f1045a858eaa012ce03f9bc8">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>labels.yml</strong><dd><code>Add Tools Forecasts repository label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/e-picsa/picsa-apps/pull/680/files#diff-080b7ef0dc11b28f262ea02985043c6229e353ecfdd5920b4d3b19f369f85dc6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

### Diagram


```mermaid
flowchart TD
  A["Forecast Page UI"] -- "click refresh" --> B["handleForceRefresh()"]
  B --> C["ForecastService.forceRefresh()"]
  C --> D["loadForecastsForCountry(force:true)"]
  D --> E["loadServerForecasts (bypass gt(id))"]
  E --> F["upsertPreservingAttachments"]
  F --> G["markSyncSuccess / offline / error"]
  G --> H["syncStatus signal (idle/updating/success/stale/offline/error)"]
  H --> I["Toolbar badge + Refresh button + Snackbar/Banner"]
```